### PR TITLE
Quick fix on grunt clean task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,6 +58,7 @@ module.exports = function (grunt) {
         },
 
         clean: {
+            force: true,
             build: ['dist']
         }
 


### PR DESCRIPTION
This commit fix a minor bug when running grunt build where the `dist` folder would not be removed if not empty.