### PR TITLE
Fix copy/paste on login screen

### DIFF
--- a/app/public/js/system/core.js
+++ b/app/public/js/system/core.js
@@ -130,7 +130,7 @@ appSystem.navBarUserUnAuthenticated = function() {
     nativeMenuBar = new gui.Menu({ type: "menubar" });
 
     nativeMenuBar.createMacBuiltin("Soundnode", {
-        hideEdit: true,
+        hideEdit: false,
         hideWindow: false
     });
 


### PR DESCRIPTION
This should allow users to copy / paste their information.

There are some other bugs, but they should be addressed after playback has been updated/changed. 

Play/pause doesn’t update in the menu is don’t use them, which would require an full update to how playback is handled

Related issues: #238 