### PR TITLE
Introduce window closing behavior more consistent with OS X software.

### DIFF
--- a/app/public/js/common/playerService.js
+++ b/app/public/js/common/playerService.js
@@ -1,4 +1,5 @@
 'use strict'
+var gui = require('nw.gui');
 
 app.factory('playerService', function($rootScope, $log, $timeout, notificationFactory) {
 
@@ -119,6 +120,9 @@ app.factory('playerService', function($rootScope, $log, $timeout, notificationFa
             body: user,
             icon: thumbnail
         });
+        songNotification.onclick = function () {
+            gui.Window.get().show();
+        }
 
         $rootScope.isSongPlaying = true;
     };

--- a/app/public/js/system/core.js
+++ b/app/public/js/system/core.js
@@ -312,7 +312,12 @@ appGUI.getGUI = gui.Window.get();
 // close the App
 appGUI.close = function () {
     var guiWin = this.getGUI;
-    guiWin.close(true);
+    if (process.platform !== "darwin") {
+        guiWin.close(true);
+    }
+    else {
+        guiWin.hide();
+    }
 };
 
 // minimize the App
@@ -326,6 +331,12 @@ appGUI.maximize = function () {
     var guiWin = this.getGUI;
     guiWin.maximize();
 };
+
+// reopen the App, this is OS X specific
+gui.App.on('reopen', function() {
+    var guiWin = appGUI.getGUI;
+    guiWin.show();
+});
 
 // open dev tools
 appGUI.openDevTools = function () {


### PR DESCRIPTION
This changes the behavior of the window on OS X so that the app isn't quit completely when closing the window. It only hides the window. Clicking the app in the dock will show the window again. This behavior is more consistent with OS X software.