### PR TITLE
Clicking on artist's name in playlist goes to artist's profile. (Closes #288)

### DIFF
--- a/app/views/playlists/playlists.html
+++ b/app/views/playlists/playlists.html
@@ -46,7 +46,7 @@
                         <div class="songList_item_container_info">
                             <h2 class="songList_item_song_tit">{{ tracks.title }}</h2>
                             <h4 class="songList_item_song_user">
-                                <span class="songList_item_song_info">by: {{ tracks.user.username }} </span>
+                                <span class="songList_item_song_info" ui-sref="profile({id: {{ tracks.user.id }}})">by: {{ tracks.user.username }} </span>
                                 <span class="songList_item_song_info">{{ formatSongDuration (tracks.duration) }}</span>
                                 <span class="songList_item_song_info">
                                     <a ng-click="removeFromPlaylist(tracks.id, data.id)"> <i class="fa fa-trash"></i> remove</a>


### PR DESCRIPTION
Just as the title says, a user can now click on an artist's name in a playlist to open the artist's profile.

I just copied the same functionality that already exists for search results.