### PR TITLE
fix display action buttons linux and mac

### DIFF
--- a/app/public/js/common/appCtrl.js
+++ b/app/public/js/common/appCtrl.js
@@ -6,7 +6,7 @@ app.controller('AppCtrl', function ($rootScope, $scope, $window, $log, ngDialog)
     $scope.isSettingsVisible = false;
 
     // Os detection
-    $scope.isRunningLinux = process.platform == 'linux32' || 'linux64';
+    $scope.isRunningLinux = process.platform == 'linux32' || process.platform == 'linux32';
     $scope.isRunningWindows = process.platform == 'win32';
     $scope.isRunningMac = process.platform == 'darwin';
 

--- a/app/views/common/actionButtonsWindows.html
+++ b/app/views/common/actionButtonsWindows.html
@@ -1,9 +1,11 @@
-<li class="windowAction_item " id="minimizeApp">
-    <i class="fa fa-minus"></i>
-</li>
-<li class="windowAction_item " id="expandApp">
-    <i class="fa fa-square-o"></i>
-</li>
-<li class="windowAction_item " id="closeApp">
-    <i class="fa fa-times"></i>
-</li>
+<ul>
+    <li class="windowAction_item " id="minimizeApp">
+        <i class="fa fa-minus"></i>
+    </li>
+    <li class="windowAction_item " id="expandApp">
+        <i class="fa fa-square-o"></i>
+    </li>
+    <li class="windowAction_item " id="closeApp">
+        <i class="fa fa-times"></i>
+    </li>
+</ul>


### PR DESCRIPTION
Linux and Mac actionButtons were displaying both at the same time.. also fix windows actionButton directive that was not in W3C list standards.