### PR TITLE
overflow: hidden; on body to prevent overscroll effect in OSX

### DIFF
--- a/app/public/stylesheets/sass/_components/_default.scss
+++ b/app/public/stylesheets/sass/_components/_default.scss
@@ -12,6 +12,7 @@ body {
   font: 62.5% 'Open Sans', helvetica, sans-serif, arial !important;
   color: $defaultColor;
   height: 100%;
+  overflow: hidden;
   -webkit-user-select: none;
   letter-spacing: 1px;
 }


### PR DESCRIPTION
Hi,

nw.js overscrolls (this sort of bounce effect that OSX has) so this prevents it.

