### PR TITLE
removes unstreamable tracks from data fetched from API in playlists

### DIFF
--- a/app/public/js/playlists/playlistsCtrl.js
+++ b/app/public/js/playlists/playlistsCtrl.js
@@ -9,6 +9,14 @@ app.controller('PlaylistsCtrl', function ($scope, SCapiService, $rootScope, $log
 
     SCapiService.get(endpoint, params)
         .then(function(data) {
+            data.forEach(function(playlist, i) {
+                var l = playlist.tracks.length;
+                while(l--) {
+                    if(!playlist.tracks[l].streamable) {
+                        data[i].tracks.splice(l, 1);
+                    }
+                }
+            });
             $scope.data = data;
         }, function(error) {
             console.log('error', error);
@@ -64,7 +72,7 @@ app.controller('PlaylistsCtrl', function ($scope, SCapiService, $rootScope, $log
             }, function(error) {
                 console.log('error', error);
             });
-        
+
     };
 
     /**


### PR DESCRIPTION
While this fix prevents soundnode to play an unstreamable track in a playlist, it could be better adding a global setting like "show unstreamable tracks grayed out".