### PR TITLE
Make copy/pasting avaliable in Mac

### DIFF
--- a/app/public/js/system/core.js
+++ b/app/public/js/system/core.js
@@ -177,7 +177,7 @@ appSystem.navBarUserAuthenticated = function() {
     nativeMenuBar = new gui.Menu({ type: "menubar" });
 
     nativeMenuBar.createMacBuiltin("Soundnode", {
-        hideEdit: true,
+        hideEdit: false,
         hideWindow: false
     });
 


### PR DESCRIPTION
This enables the edit menu in the mac menubar which has the built in copy/paste functionality.

Closes #395 