### PR TITLE
Fix end of queue exception [TypeError: Cannot read property 'songId' of undefined]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,4 +15,3 @@ trim_trailing_whitespace = false
 
 [COMMIT_EDITMSG]
 max_line_length = 0
-

--- a/app/public/js/common/playerService.js
+++ b/app/public/js/common/playerService.js
@@ -272,7 +272,6 @@ app.factory('playerService', function($rootScope, $log, $timeout, $window, $stat
 
         if ( $rootScope.shuffle ) {
             shuffle();
-            this.playNewSong();
         } else if ( ! $rootScope.repeat ) {
             queueEnded = !queueService.next();
         } else {

--- a/app/public/js/common/playerService.js
+++ b/app/public/js/common/playerService.js
@@ -247,9 +247,9 @@ app.factory('playerService', function($rootScope, $log, $timeout, $window, $stat
             return false;
         }
 
-        if ( $rootScope.shuffle && ! $rootScope.repeat ) {
+        if ( $rootScope.shuffle ) {
             shuffle();
-        } else if ( ! $rootScope.repeat ) {
+        } else {
             queueService.prev();
         }
 
@@ -264,17 +264,27 @@ app.factory('playerService', function($rootScope, $log, $timeout, $window, $stat
      */
     player.playNextSong = function() {
 
+        var queueEnded = false;
+
         if ( $rootScope.lock ) {
             return false;
         }
 
-        if ( $rootScope.shuffle && ! $rootScope.repeat ) {
+        if ( $rootScope.shuffle ) {
             shuffle();
+            this.playNewSong();
         } else if ( ! $rootScope.repeat ) {
-            queueService.next();
+            queueEnded = !queueService.next();
+        } else {
+            if( ! queueService.next() ) {
+                queueService.currentPosition = 0;
+            }
         }
 
-        this.playNewSong();
+        if( ! queueEnded ) {
+            this.playNewSong();
+        }
+
     };
 
     /**

--- a/app/public/js/common/queueService.js
+++ b/app/public/js/common/queueService.js
@@ -96,20 +96,23 @@ app.factory('queueService', function() {
      * @method prev
      */
     Queue.prev = function() {
-        if ( this.currentPosition !== 0 ) {
+        if ( this.currentPosition > 0 ) {
             --this.currentPosition;
         }
     };
 
     /**
      * Increase (by 1) currentPosition in the list
-     * if currentPosition not equal to list size
+     * if currentPosition is less than list size
      * @method next
+     * @return {false} if no next track available or {true} otherwise
      */
     Queue.next = function() {
-        if ( this.currentPosition !== this.size() ) {
+        if ( this.currentPosition < this.size()-1 ) {
             ++this.currentPosition;
+            return true;
         }
+        return false;
     };
 
     /**


### PR DESCRIPTION
When the last song of the queue ended, an exception was thrown because queueService.next() caused an out of bounds for currentPosition in the Queue.list array. This pull request fixes this.