### PR TITLE
Make people's comments clickable (to go to their profile)

### DIFF
--- a/app/public/stylesheets/sass/_components/_track.scss
+++ b/app/public/stylesheets/sass/_components/_track.scss
@@ -117,6 +117,14 @@
                     color: $defaultColor;
                     font-size: 0.9em;
                 }
+
+                & .user_name {
+                    cursor: pointer;
+                    display: initial;
+                    font-size: inherit;
+                    font-weight: inherit;
+                    color: inherit;
+                }
             }
 
             & p {

--- a/app/public/stylesheets/sass/_components/_user.scss
+++ b/app/public/stylesheets/sass/_components/_user.scss
@@ -9,6 +9,7 @@
     display: block;
     border-radius: 50px;
     float: left;
+    cursor: pointer;
 }
 
 .user_inner {

--- a/app/views/track/track.html
+++ b/app/views/track/track.html
@@ -52,9 +52,10 @@
 
         <div class="commentsContainer">
             <div class="comment" ng-repeat="comment in comments">
-                <img ng-src="{{comment.user.avatar_url}}" alt="{{comment.user.username}}" class="user_thumb">
+                <img ng-src="{{comment.user.avatar_url}}" alt="{{comment.user.username}}" class="user_thumb" ui-sref="profile({ id: comment.user.id })">
 
-                <h3>{{comment.user.username}}
+                <h3>
+                    <a ui-sref="profile({ id: comment.user.id })" class="user_name">{{comment.user.username}}</a>
                     <span>at {{comment.timestamp | date : 'mm:ss'}}</span>
                     <span class="date">{{comment.created_at | limitTo: 19}}</span>
                 </h3>


### PR DESCRIPTION
Fixes: https://github.com/Soundnode/soundnode-app/issues/393

Making user image and user name clickable, links lead to user profile.
Using the same `.user_name` class for consistency, keeping original styling applied to comments.