### PR TITLE
Feature: Show and make reposts - integrate SoundCloud API v2 [in progress]

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -209,7 +209,9 @@
 
 <!-- services/factories -->
 <script src="public/js/common/queueService.js"></script>
+<script src="public/js/common/rateLimitService.js"></script>
 <script src="public/js/common/SCapiService.js"></script>
+<script src="public/js/common/SC2apiService.js"></script>
 <script src="public/js/common/playerService.js"></script>
 <script src="public/js/common/notificationFactory.js"></script>
 
@@ -240,6 +242,7 @@
 <script src="public/js/common/songDirective.js"></script>
 <script src="public/js/common/openExternalLinkDirective.js"></script>
 <script src="public/js/common/favoriteSongDirective.js"></script>
+<script src="public/js/common/repostedSongDirective.js"></script>
 <script src="public/js/common/showMoreDirective.js"></script>
 <script src="public/js/common/tracksDirective.js"></script>
 <script src="public/js/common/playlistDirective.js"></script>

--- a/app/public/js/common/SC2apiService.js
+++ b/app/public/js/common/SC2apiService.js
@@ -1,0 +1,136 @@
+'use strict';
+
+// Service to work with SoundCloud API v2
+// Note: v2 API is not officially supported by SoundCloud yet,
+// be careful using these methods, because they might stop working at any moment
+
+app.service('SC2apiService', function (
+    $rootScope,
+    $window,
+    $http,
+    $q,
+    rateLimit
+) {
+
+    /**
+     * Soundcloud v2 API endpoint
+     * @type {String}
+     */
+    var SOUNDCLOUD_API_V2 = 'https://api-v2.soundcloud.com/';
+
+    /**
+     * Store URL of the next page, when acessing resource supporting pagination
+     * @type {String}
+     */
+    var nextPageUrl = '';
+
+
+    // Public API
+
+    /**
+     * Get current user stream
+     * @return {promise}
+     */
+    this.getStream = function () {
+        var params = {
+            limit: 30
+        };
+        return sendRequest('stream', { params: params })
+            .then(onResponseSuccess)
+            .then(updateNextPageUrl)
+            .catch(onResponseError);
+    };
+
+    /**
+     * Get next page for last requested resource
+     * @return {promise}
+     */
+    this.getNextPage = function () {
+        if (!nextPageUrl) {
+            return $q.reject('No next page URL');
+        }
+        return sendRequest(nextPageUrl)
+            .then(onResponseSuccess)
+            .then(updateNextPageUrl)
+            .catch(onResponseError);
+    };
+
+    /**
+     * Get extended information about particular tracks
+     * @param  {array} ids - tracks ids
+     * @return {promise}
+     */
+    this.getTracksByIds = function (ids) {
+        var params = {
+            urns: ids.map(function (trackId) {
+                return 'soundcloud:tracks:' + trackId.toString();
+            }).join(',')
+        };
+        return sendRequest('tracks', { params: params })
+            .then(onResponseSuccess)
+            .catch(onResponseError);
+    };
+
+    // Private methods
+
+    /**
+     * Utility method to send http request
+     * @param  {resource} resource - url part with resource name
+     * @param  {object} config   - options for $http
+     * @param  {object} options  - custom options (show loading, etc)
+     * @return {promise}
+     */
+    function sendRequest(resource, config, options) {
+        config = config || {};
+        // Check if passed absolute url
+        if (resource.indexOf('http') === 0) {
+            config.url = resource;
+        } else {
+            config.url = SOUNDCLOUD_API_V2 + resource;
+        }
+        config.params = config.params || {};
+        config.params.oauth_token = $window.scAccessToken;
+
+        options = options || {};
+        if (options.loading !== false) {
+            $rootScope.isLoading = true;
+        }
+
+        return $http(config);
+    }
+
+    /**
+     * Response success handler
+     * @param  {object} response - $http response object
+     * @return {object}          - response data
+     */
+    function onResponseSuccess(response) {
+        if (response.status !== 200) {
+            return $q.reject(response.data);
+        }
+        return response.data;
+    }
+
+    /**
+     * Response error handler
+     * @param  {object} response - $http response object
+     * @return {promise}
+     */
+    function onResponseError(response) {
+        if (response.status === 429) {
+            rateLimit.showNotification();
+        }
+        return $q.reject(response.data);
+    }
+
+    /**
+     * Update value of the next page for paginatable resources
+     * @param  {data} data - response data
+     * @return {object}    - pass through data to use function in promise chain
+     */
+    function updateNextPageUrl(data) {
+        nextPageUrl = data.next_href || '';
+        return data;
+    }
+
+});

--- a/app/public/js/common/favoriteSongDirective.js
+++ b/app/public/js/common/favoriteSongDirective.js
@@ -2,11 +2,7 @@
 
 app.directive('favoriteSong', function(
     $rootScope,
-    $log,
     SCapiService,
-    $timeout,
-    $state,
-    $stateParams,
     notificationFactory
 ) {
     return {

--- a/app/public/js/common/queueCtrl.js
+++ b/app/public/js/common/queueCtrl.js
@@ -91,6 +91,27 @@ app.controller('QueueCtrl', function(
     };
 
     /**
+     * repost track from queue
+     * @param  {object} $event - Angular event
+     * @return {promise}
+     */
+    $scope.repost = function ($event) {
+        var trackData = $($event.target).closest('.queueListView_list_item').data();
+        var songId = trackData.songId;
+
+        return SCapiService.createRepost(songId)
+            .then(function (status) {
+                if (angular.isObject(status)) {
+                    notificationFactory.success('Song added to reposts!');
+                    utilsService.markTrackAsReposted(songId);
+                }
+            })
+            .catch(function (status) {
+                notificationFactory.error('Something went wrong!');
+            });
+    };
+
+    /**
      * add track to playlist
      * @param $event
      */

--- a/app/public/js/common/rateLimitService.js
+++ b/app/public/js/common/rateLimitService.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// Displays popup with a warning that rate limit is reached, with a link
+// to SoundCloud docs attached. Call it when response returns 429 status
+app.service('rateLimit', function (
+    $http,
+    ngDialog
+) {
+    this.showNotification = function () {
+        return ngDialog.open({
+            showClose: false,
+            template: 'views/common/modal.html',
+            controller: ['$scope', function ($scope) {
+                var urlGH = 'https://api.github.com/repos/Soundnode/soundnode-about/contents/rate-limit-reached.html';
+                var config = {
+                    headers: {
+                        'Accept': 'application/vnd.github.v3.raw+json'
+                    }
+                };
+
+                $scope.content = '';
+
+                $scope.closeModal = function () {
+                    ngDialog.closeAll();
+                };
+
+                $http.get(urlGH, config)
+                    .then(function (response) {
+                        $scope.content = response.data;
+                    })
+                    .catch(function (response) {
+                        console.log('Error', response.data);
+                    });
+            }]
+        });
+    };
+});

--- a/app/public/js/common/repostedSongDirective.js
+++ b/app/public/js/common/repostedSongDirective.js
@@ -1,0 +1,51 @@
+'use strict';
+
+app.directive('repostedSong', function (
+    $rootScope,
+    SCapiService,
+    notificationFactory
+) {
+    return {
+        restrict: 'A',
+        scope: {
+            reposted: '='
+        },
+        link: function ($scope, elem, attrs) {
+            var songId;
+
+            elem.bind('click', function () {
+                songId = attrs.songId;
+
+                if (this.classList.contains('reposted')) {
+
+                    SCapiService.deleteRepost(songId)
+                        .then(function (status) {
+                            if (angular.isObject(status)) {
+                                notificationFactory.success('Song removed from reposts!');
+                                $scope.reposted = false;
+                            }
+                        })
+                        .catch(function () {
+                            notificationFactory.error('Something went wrong!');
+                        });
+
+                } else {
+
+                    SCapiService.createRepost(songId)
+                        .then(function (status) {
+                            if (angular.isObject(status)) {
+                                notificationFactory.success('Song added to reposts!');
+                                $scope.reposted = true;
+                            }
+                        })
+                        .catch(function () {
+                           notificationFactory.error('Something went wrong!');
+                        });
+
+                }
+
+            });
+
+        }
+    };
+});

--- a/app/public/js/common/tracksDirective.js
+++ b/app/public/js/common/tracksDirective.js
@@ -3,7 +3,11 @@
 app.directive('tracks', function () {
     return {
         restrict: 'AE',
-        scope: { data: '=' },
+        scope: {
+            data: '=',
+            user: '=',
+            type: '='
+        },
         templateUrl: "views/common/tracks.html"
-    }
+    };
 });

--- a/app/public/js/common/utilsService.js
+++ b/app/public/js/common/utilsService.js
@@ -1,14 +1,27 @@
 'use strict';
 
 app.factory('utilsService', function(
-    queueService
+    queueService,
+    SCapiService,
+    $q
 ) {
     /**
      * API (helpers/utils) to interact with the UI
      * and the rest of the App
      * @type {{}}
      */
-    var Utils = {};
+    var Utils = {
+        /**
+         * Store cache of fetched likes ids
+         * @type {Array}
+         */
+        likesIds: [],
+        /**
+         * Store cache of fetched reposts ids
+         * @type {Array}
+         */
+        repostsIds: []
+    };
 
     /**
      * Find track and mark as favorited
@@ -16,9 +29,19 @@ app.factory('utilsService', function(
      * @method markTrackAsFavorite
      */
     Utils.markTrackAsFavorite = function(trackId) {
-        var track = document.querySelector('a[data-song-id="' + trackId + '"]');
+        var track = document.querySelector('a[favorite-song][data-song-id="' + trackId + '"]');
         track.classList.add('liked');
         //track.setAttribute('favorite', true);
+    };
+
+    /**
+     * Find track and mark as reposted
+     * @param trackId (track id)
+     * @method markTrackAsReposted
+     */
+    Utils.markTrackAsReposted = function(trackId) {
+        var track = document.querySelector('a[reposted-song][data-song-id="' + trackId + '"]');
+        track.classList.add('reposted');
     };
 
     /**
@@ -84,6 +107,51 @@ app.factory('utilsService', function(
         return list;
     };
 
+    /**
+     * Fetch ids of liked tracks and apply them to existing collection
+     * @param  {array} collection - stream collection or tracks array
+     * @param  {boolean} fromCache  - if should make request to API
+     * @return {promise}            - promise with original collection
+     */
+    Utils.updateTracksLikes = function (collection, fromCache) {
+        var fetchLikedIds = fromCache ?
+            $q(function (resolve) { resolve(Utils.likesIds) }) :
+            SCapiService.getFavoritesIds();
+        return fetchLikedIds.then(function (ids) {
+            if (!fromCache) {
+                Utils.likesIds = ids;
+            }
+            collection.forEach(function (item) {
+                var track = item.track || item;
+                // modify each track by reference
+                track.user_favorite = Utils.likesIds.indexOf(track.id) > -1;
+            });
+            return collection;
+        });
+    };
+
+    /**
+     * Fetch ids of reposted tracks and apply them to existing collection
+     * @param  {array} collection - stream collection or tracks array
+     * @param  {boolean} fromCache  - if should make request to API
+     * @return {promise}            - promise with original collection
+     */
+    Utils.updateTracksReposts = function (collection, fromCache) {
+        var fetchRepostsIds = fromCache ?
+            $q(function (resolve) { resolve(Utils.repostsIds) }) :
+            SCapiService.getRepostsIds();
+        return fetchRepostsIds.then(function (ids) {
+            if (!fromCache) {
+                Utils.repostsIds = ids;
+            }
+            collection.forEach(function (item) {
+                var track = item.track || item;
+                // modify each track by reference
+                track.user_reposted = Utils.repostsIds.indexOf(track.id) > -1;
+            });
+            return collection;
+        });
+    };
 
     return Utils;
 

--- a/app/public/js/favorites/favoritesCtrl.js
+++ b/app/public/js/favorites/favoritesCtrl.js
@@ -1,6 +1,11 @@
 'use strict';
 
-app.controller('FavoritesCtrl', function ($scope, SCapiService, $rootScope) {
+app.controller('FavoritesCtrl', function (
+    $scope,
+    $rootScope,
+    SCapiService,
+    utilsService
+) {
     var endpoint = 'me/favorites'
         , params = 'linked_partitioning=1';
 
@@ -14,6 +19,7 @@ app.controller('FavoritesCtrl', function ($scope, SCapiService, $rootScope) {
         }, function(error) {
             console.log('error', error);
         }).finally(function() {
+            utilsService.updateTracksReposts($scope.data);
             $rootScope.isLoading = false;
         });
 
@@ -28,6 +34,7 @@ app.controller('FavoritesCtrl', function ($scope, SCapiService, $rootScope) {
                 for ( var i = 0; i < data.collection.length; i++ ) {
                     $scope.data.push( data.collection[i] )
                 }
+                utilsService.updateTracksReposts(data.collection, true);
             }, function(error) {
                 console.log('error', error);
             }).finally(function(){

--- a/app/public/js/profile/profileCtrl.js
+++ b/app/public/js/profile/profileCtrl.js
@@ -4,7 +4,13 @@
 
 'use strict'
 
-app.controller('ProfileCtrl', function ($scope, SCapiService, $rootScope, $stateParams) {
+app.controller('ProfileCtrl', function (
+    $scope,
+    $rootScope,
+    $stateParams,
+    SCapiService,
+    utilsService
+) {
 
     //ctrl variables
     var userId = $stateParams.id;
@@ -36,6 +42,7 @@ app.controller('ProfileCtrl', function ($scope, SCapiService, $rootScope, $state
         }, function(error) {
             console.log('error', error);
         }).finally(function() {
+            utilsService.updateTracksReposts($scope.data);
             $rootScope.isLoading = false;
         });
 
@@ -60,6 +67,7 @@ app.controller('ProfileCtrl', function ($scope, SCapiService, $rootScope, $state
                 for ( var i = 0; i < data.collection.length; i++ ) {
                     $scope.data.push( data.collection[i] )
                 }
+                utilsService.updateTracksReposts(data.collection, true);
             }, function(error) {
                 console.log('error', error);
             }).finally(function(){

--- a/app/public/js/search/searchCtrl.js
+++ b/app/public/js/search/searchCtrl.js
@@ -1,6 +1,13 @@
 'use strict';
 
-app.controller('searchCtrl', function ($scope, $http, $stateParams, SCapiService, $rootScope) {
+app.controller('searchCtrl', function (
+    $scope,
+    $rootScope,
+    $http,
+    $stateParams,
+    SCapiService,
+    utilsService
+) {
 
     $scope.title = 'Results for: ' + $stateParams.q;
     $scope.data = '';
@@ -12,6 +19,7 @@ app.controller('searchCtrl', function ($scope, $http, $stateParams, SCapiService
         }, function(error) {
             console.log('error', error);
         }).finally(function(){
+            utilsService.updateTracksReposts($scope.data);
             $rootScope.isLoading = false;
         });
 
@@ -26,6 +34,7 @@ app.controller('searchCtrl', function ($scope, $http, $stateParams, SCapiService
                 for ( var i = 0; i < data.collection.length; i++ ) {
                     $scope.data.push( data.collection[i] )
                 }
+                utilsService.updateTracksReposts(data.collection, true);
             }, function(error) {
                 console.log('error', error);
             }).finally(function(){

--- a/app/public/js/tag/tagCtrl.js
+++ b/app/public/js/tag/tagCtrl.js
@@ -1,6 +1,13 @@
 'use strict';
 
-app.controller('tagCtrl', function ($scope, $http, $stateParams, SCapiService, $rootScope) {
+app.controller('tagCtrl', function (
+    $scope,
+    $rootScope,
+    $http,
+    $stateParams,
+    SCapiService,
+    utilsService
+) {
     var tagUrl = encodeURIComponent($stateParams.name);
 
     $scope.tag = $stateParams.name;
@@ -12,11 +19,12 @@ app.controller('tagCtrl', function ($scope, $http, $stateParams, SCapiService, $
         }, function (error) {
             console.log('error', error);
         }).finally(function () {
+            utilsService.updateTracksReposts($scope.data);
             $rootScope.isLoading = false;
         });
 
     $scope.loadMore = function () {
-        if ( $scope.busy || !SCapiService.isNextPage()) {
+        if ( $scope.busy || !SCapiService.next_page) {
             return;
         }
         $scope.busy = true;
@@ -26,6 +34,7 @@ app.controller('tagCtrl', function ($scope, $http, $stateParams, SCapiService, $
                 for (var i = 0; i < data.collection.length; i++) {
                     $scope.data.push(data.collection[i])
                 }
+                utilsService.updateTracksReposts(data.collection, true);
             }, function (error) {
                 console.log('error', error);
             }).finally(function () {

--- a/app/public/stylesheets/sass/_components/_playlist-songs.scss
+++ b/app/public/stylesheets/sass/_components/_playlist-songs.scss
@@ -20,6 +20,8 @@
     display: block;
     margin: 0 0 10px 0;
     cursor: pointer;
+    width: 100%;
+    float: none;
 
     & span {
       cursor: pointer;

--- a/app/public/stylesheets/sass/_components/_songlist.scss
+++ b/app/public/stylesheets/sass/_components/_songlist.scss
@@ -88,15 +88,33 @@ div.active {
   }
 }
 
-.songList_item_song_user {
+.songList_item_song_info {
   display: block;
   color: $defaultColor;
   font-size: 11px;
   text-transform: uppercase;
+
+}
+
+.songList_item_song_user {
+  width: 165px;
+  float: left;
+}
+
+.songList_item_repost {
+  & > i {
+    color: inherit;
+    cursor: default;
+  }
+  & > a {
+    font-size: 8px;
+  }
 }
 
 .songList_item_song_length {
   float: right;
+  width: 45px;
+  text-align: right
 }
 
 .songList_item_song_tit {
@@ -149,7 +167,8 @@ div.active {
           margin-right: 0;
       }
 
-      &.liked {
+      &.liked,
+      &.reposted {
           & > .fa {
               color: $scColor;
           }

--- a/app/views/common/queueList.html
+++ b/app/views/common/queueList.html
@@ -28,6 +28,7 @@
                 <ul class="queueListView_list_item_options_list" >
                     <li class="queueListView_list_item_options_list_button" ng-click="remove($event); $event.stopPropagation();">Remove</li>
                     <li class="queueListView_list_item_options_list_button" ng-click="like($event); $event.stopPropagation();">Like</li>
+                    <li class="queueListView_list_item_options_list_button" ng-click="repost($event); $event.stopPropagation();">Repost</li>
                     <li class="queueListView_list_item_options_list_button" ng-click="addToPlaylist($event); $event.stopPropagation();">Add to playlist</li>
                     <li class="queueListView_list_item_options_list_button" ng-click="gotoTrack($event); $event.stopPropagation();">Go to track</li>
                 </ul>

--- a/app/views/common/tracks.html
+++ b/app/views/common/tracks.html
@@ -32,15 +32,30 @@
 <section class="songList_item_inner">
     <h2 class="songList_item_song_tit" title="{{ data.title }}" ui-sref="track({id: {{data.id}}})">{{ data.title }}</h2>
 
-    <h3 class="songList_item_song_user">
-      <a ui-sref="profile({id: {{data.user.id}}})">{{ data.user.username }}</a>
-      <span ng-controller="AppCtrl" class="songList_item_song_length"> {{ formatSongDuration (data.duration) }}</span>
+    <h3 class="songList_item_song_info clearfix">
+        <div class="songList_item_song_user">
+            <a ui-sref="profile({id: {{data.user.id}}})">
+                {{ data.user.username }}
+            </a>
+            <span class="songList_item_repost" ng-if="type === 'track-repost'">
+                <i class="fa fa-retweet"></i>
+                <a ui-sref="profile({ id: {{ user.id }} })" title="Reposted by {{ user.username }}">
+                    {{ user.username }}
+                </a>
+            </span>
+        </div>
+        <div ng-controller="AppCtrl" class="songList_item_song_length">
+            {{ formatSongDuration (data.duration) }}
+        </div>
     </h3>
 
     <div class="songList_item_song_details">
         <div class="songList_item_actions">
             <a favorite-song data-song-id="{{ data.id }}" favorite="data.user_favorite" ng-class="{liked: data.user_favorite}" title="{{data.user_favorite ? 'Unlike' : 'Like'}}">
                 <i class="fa fa-heart"></i>
+            </a>
+            <a reposted-song data-song-id="{{ data.id }}" reposted="data.user_reposted" ng-class="{ reposted: data.user_reposted }" title="{{data.user_reposted ? 'Unpost' : 'Repost'}}" ng-if="data.user.id !== $root.userId">
+                <i class="fa fa-retweet"></i>
             </a>
             <a data-song-id="{{ data.id }}" data-song-name="{{ data.title }}" playlist title="Add to playlist"> <i class="fa fa-bookmark"></i></a>
             <a href="{{ data.permalink_url }}" open-external target="_blank" title="Permalink"> <i class="fa fa-external-link"></i></a>

--- a/app/views/stream/stream.html
+++ b/app/views/stream/stream.html
@@ -1,18 +1,17 @@
 <div class="streamView">
     <h1> {{ title }}</h1>
-    
+
     <!-- Song list wrapper -->
     <div class="streamView_inner">
-        <ul class="songList" 
-            infinite-scroll='loadMore()' 
+        <ul class="songList"
+            infinite-scroll='loadMore()'
             infinite-scroll-distance='0'
             infinite-scroll-container='".mainView"'
             infinite-scroll-immediate-check='false' >
 
-            <li class="songList_item" ng-repeat="data in data"
-                ng-if="data.type == 'track' || data.type == 'track-repost' && data.origin.streamable" >
+            <li class="songList_item" ng-repeat="data in data">
 
-                <tracks data="data.origin"/>
+                <tracks data="data.track" type="data.type" user="data.user"/>
 
             </li>
         </ul>


### PR DESCRIPTION
Note: work is still in progress

Implementation of https://github.com/Soundnode/soundnode-app/issues/291: show reposts and allow to make resposts.

As discussed in the issue, it is possible to work with reposts only using SoundCloud API v2. In this PR:
- introducing new service to work with v2 API, similar to existing service
- moving a "rate limit reached" dialog to a separate service to reuse it for both v1 and v2 API
- modifying stream page to work with v2 API response: track object is almost the same, except it is stored in the `track` property of collection item (`origin` property for v1 API) and it does not have `user_favorite` prop, so it is now set by force.

Basically, I would love to hear some feedback if I am going in the right direction and may continue working on reposts using this base. I am not sure if the entire application should be migrated to v2 at once. Thanks!