### PR TITLE
Closes #380. Hide search typeahead on submit.

### DIFF
--- a/app/public/js/search/searchInputCtrl.js
+++ b/app/public/js/search/searchInputCtrl.js
@@ -3,19 +3,27 @@
 app.controller('SearchInputCtrl', function ($scope, $http, $state, $window, SCapiService) {
     $scope.title = 'Search results';
 
+    var isTypeaheadAborted = false;
+
     $scope.onSubmit = function(keyword) {
         $state.go('search', {q: keyword}, {reload: true});
         $scope.blurTypeahead();
+        isTypeaheadAborted = true;
     }
 
     $scope.typeahead = function(keyword) {
         var dropdown = document.getElementById('searchDropDown');
-            dropdown.innerHTML = '';
+        dropdown.innerHTML = '';
 
+        isTypeaheadAborted = false;
 
         // search for artists
         SCapiService.search('users', 4, keyword)
                     .then(function(data) {
+                        if (isTypeaheadAborted) {
+                            $scope.blurTypeahead();
+                            return false;
+                        }
 
                         if (data.collection.length < 1) {
                             var error = document.createElement('div');
@@ -54,6 +62,10 @@ app.controller('SearchInputCtrl', function ($scope, $http, $state, $window, SCap
         // search for tracks
         SCapiService.search('tracks', 4, keyword)
                     .then(function(data) {
+                        if (isTypeaheadAborted) {
+                            $scope.blurTypeahead();
+                            return false;
+                        }
                         if (data.collection.length < 1) {
                             return false;
                         }
@@ -87,6 +99,10 @@ app.controller('SearchInputCtrl', function ($scope, $http, $state, $window, SCap
                         dropdown.appendChild(showAll);
                     })
                     .then(function(){
+                        if (isTypeaheadAborted) {
+                            $scope.blurTypeahead();
+                            return false;
+                        }
                         dropdown.style.display = 'block';
                     })
                     .catch(function(err) {


### PR DESCRIPTION
If user types letters in search input and immediately hits "Enter", he will be redirected to a search results page. As soon as each typed in character sends a request, the response comes a bit later then pressed "Enter", so typeahead gets rendered after a search page shows up, which might be a bit confusing. PR fixes it, typeahead won't be displayed after "Enter" hit.