### PR TITLE
Remove min-width from mainView

### DIFF
--- a/app/public/stylesheets/sass/_components/_view-container.scss
+++ b/app/public/stylesheets/sass/_components/_view-container.scss
@@ -7,8 +7,8 @@
   height: 100%;
 
   & > div {
+    min-width: 130px;
     max-width: 100%;
-    min-width: 930px;
     margin: 0 auto;
   }
 
@@ -40,4 +40,3 @@
       margin-right: 0;
     }
 }
-


### PR DESCRIPTION
This makes the app more usable on smaller width screens (EG/ Vertical monitors)

The existing flex view should automatically adjust the lists to fit

Screenshot of new CSS Fix (Compared to old version below
![screenshot from 2015-11-29 09-01-33](https://cloud.githubusercontent.com/assets/5661105/11454156/cfabdee2-9677-11e5-9381-9868ebc843be.png)

Old CSS
![screenshot from 2015-11-29 09-02-24](https://cloud.githubusercontent.com/assets/5661105/11454168/ed7d4014-9677-11e5-844a-8fbb1812a9f0.png)

