### PR TITLE
Fixed Windows OS resize bug. Tweaked resize on boot

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -20,6 +20,7 @@
     "resizable": true,
     "position": "center",
     "single-instance": true,
-    "node-remote": "localhost"
+    "node-remote": "localhost",
+    "show": false
   }
 }

--- a/app/public/js/system/guiConfig.js
+++ b/app/public/js/system/guiConfig.js
@@ -8,6 +8,7 @@ var guiConfig = {};
 guiConfig.getGUI = gui.Window.get();
 
 guiConfig.init = function () {
+    this.getGUI.show();
     this.navBarUserUnAuthenticated();
 };
 

--- a/app/public/js/system/userConfig.js
+++ b/app/public/js/system/userConfig.js
@@ -40,6 +40,7 @@ userConfig.windowState = function() {
     }
 
     gui.Window.get().on('resize', function(width, height) {
+        if (gui.Window.get().x < 100 && gui.Window.get().y < 100) return;
         userConfig.saveWindow(width, height);
     });
 };


### PR DESCRIPTION
That shoud fix #469, minimizing app caused to save weird width and height of window.
As well window now shows up after it resizes on boot so user wont be able to see when it get resized so it looks nicer.