### PR TITLE
Fixes #476 by calling $scope.$apply() when state is changed outside of the angular context.

### DIFF
--- a/app/public/js/common/songDirective.js
+++ b/app/public/js/common/songDirective.js
@@ -9,7 +9,9 @@ app.directive('song', function ($rootScope, $window, playerService) {
             elem.bind('click', function () {
                 currentEl = this;
 
-                playerService.songClicked(currentEl);
+                $scope.$apply(function() {
+                    playerService.songClicked(currentEl);
+                });
             });
 
         }

--- a/app/public/js/player/playerCtrl.js
+++ b/app/public/js/player/playerCtrl.js
@@ -117,11 +117,13 @@ app.controller('PlayerCtrl', function ($scope, $rootScope, playerService, queueS
     var playPause = new gui.Shortcut({
         key: 'MediaPlayPause',
         active: function() {
-            if ( $rootScope.isSongPlaying ) {
-                playerService.pauseSong();
-            } else {
-                playerService.playSong();
-            }
+            $scope.$apply(function() {
+                if ( $rootScope.isSongPlaying ) {
+                    playerService.pauseSong();
+                } else {
+                    playerService.playSong();
+                }
+            });
         },
         failed: function() {
             // nothing here
@@ -131,9 +133,11 @@ app.controller('PlayerCtrl', function ($scope, $rootScope, playerService, queueS
     var stop = new gui.Shortcut({
         key: 'MediaStop',
         active: function() {
-            if ( $rootScope.isSongPlaying ) {
-                playerService.pauseSong();
-            }
+            $scope.$apply(function() {
+                if ( $rootScope.isSongPlaying ) {
+                    playerService.pauseSong();
+                }
+            });
         },
         failed: function() {
             // nothing here
@@ -143,9 +147,11 @@ app.controller('PlayerCtrl', function ($scope, $rootScope, playerService, queueS
     var prevTrack = new gui.Shortcut({
         key: 'MediaPrevTrack',
         active: function() {
-            if ( $rootScope.isSongPlaying ) {
-                playerService.playPrevSong();
-            }
+            $scope.$apply(function() {
+                if ( $rootScope.isSongPlaying ) {
+                    playerService.playPrevSong();
+                }
+            });
         },
         failed: function() {
             // nothing here
@@ -155,9 +161,11 @@ app.controller('PlayerCtrl', function ($scope, $rootScope, playerService, queueS
     var nextTrack = new gui.Shortcut({
         key: 'MediaNextTrack',
         active: function() {
-            if ( $rootScope.isSongPlaying ) {
-                playerService.playNextSong();
-            }
+            $scope.$apply(function() {
+                if ( $rootScope.isSongPlaying ) {
+                    playerService.playNextSong();
+                }
+            });
         },
         failed: function() {
             // nothing here


### PR DESCRIPTION
Closes #476.

The issue was that state was being changed using methods not under angular control. When this is done, angular does not know to update the view until $scope.$apply() is called. Incidentally, $scope.$apply() is called when angular controlled functions are accessed, which is why hovering over another song triggers the state change.

I updated the media button functions along with the song click handler to call $scope.$apply(). The hotkeys seem to work as expected.