### PR TITLE
Fixed double-moving of queue when using the next and prev hotkeys on Mac

### DIFF
--- a/app/public/js/player/playerCtrl.js
+++ b/app/public/js/player/playerCtrl.js
@@ -203,7 +203,7 @@ app.controller('PlayerCtrl', function ($scope, $rootScope, playerService, queueS
     });
 
     hotkeys.add({
-        combo: ['command+right', 'ctrl+right'],
+        combo: 'ctrl+right',
         description: 'Next song',
         callback: function() {
             if ( $rootScope.isSongPlaying ) {
@@ -213,7 +213,7 @@ app.controller('PlayerCtrl', function ($scope, $rootScope, playerService, queueS
     });
 
     hotkeys.add({
-        combo: ['command+left', 'ctrl+left'],
+        combo: 'ctrl+left',
         description: 'Prev song',
         callback: function() {
             if ( $rootScope.isSongPlaying ) {


### PR DESCRIPTION
Closes #519 

NW.js has gui functionality for the Mac menu bar. The shortcuts cmd-right and cmd-left were in the standard hotkey list in the player, but the gui menu item for next and prev also had the shortcut, which calls the click function. Both the click function and the hotkey function move to the next song, so this is happening twice.

The fix is simply removing the cmd shortcuts from the hotkey list, leaving ctrl ones for windows and linux, and leaving the hotkeys in the menu bar.