### PR TITLE
Improvement on topBar for Macintosh. closes #501 closes #533

### DIFF
--- a/app/public/stylesheets/sass/_components/_dropdown.scss
+++ b/app/public/stylesheets/sass/_components/_dropdown.scss
@@ -1,6 +1,6 @@
 .dropdown {
     position: absolute;
-    top: 40px;
+    top: 36px;
     z-index: 1000;
     display: none;
     min-width: 160px;

--- a/app/public/stylesheets/sass/_components/_search.scss
+++ b/app/public/stylesheets/sass/_components/_search.scss
@@ -9,7 +9,7 @@
 
   & .search-icon {
     position: absolute;
-    top: 15px;
+    top: 10px;
     right: 5px;
     color: $defaultColor;
     transition: $transitionFastValue;
@@ -25,7 +25,7 @@
   border-radius: 0;
   color: $defaultColor;
   height: auto;
-  padding: 10px 5px 5px;
+  padding: 5px 5px 5px;
   width: 100%;
   &:focus {
     box-shadow: none;

--- a/app/public/stylesheets/sass/_components/_topFrame.scss
+++ b/app/public/stylesheets/sass/_components/_topFrame.scss
@@ -20,11 +20,11 @@
 }
 .windowAction_item {
   float: left;
-  margin: 10px 5px 0;
-  font-size: 10px;
+  margin: 13px 5px 0;
+  font-size: 7px;
   cursor: pointer;
   border-radius: 15px;
-  padding: 0px 3px;
+  padding: 1px 3px;
   letter-spacing: 0;
 
 
@@ -45,11 +45,6 @@
 .macActionButtons {
   & #closeApp {
     background: #FF4441;
-
-    & .fa {
-      position: relative;
-      top: -1px;
-    }
   }
 
   & #minimizeApp {

--- a/app/public/stylesheets/sass/_components/_topFrame.scss
+++ b/app/public/stylesheets/sass/_components/_topFrame.scss
@@ -15,17 +15,22 @@
 .windowAction {
   overflow: hidden;
   float: left;
-  margin: 5px 0 0 0;
+  margin: 7px 0 0 0;
   -webkit-app-region: no-drag;
 }
 .windowAction_item {
   float: left;
-  margin: 10px 10px 0;
+  margin: 10px 5px 0;
   font-size: 10px;
   cursor: pointer;
   border-radius: 15px;
-  padding: 2px 5px;
+  padding: 0px 3px;
   letter-spacing: 0;
+
+
+  &:first-child {
+    margin-left: 10px;
+  }
 
   &:hover .fa {
     color: $defaultColor;
@@ -39,18 +44,29 @@
 
 .macActionButtons {
   & #closeApp {
-    background: #D96C76;
+    background: #FF4441;
 
     & .fa {
       position: relative;
       top: -1px;
     }
   }
+
   & #minimizeApp {
-    background: #FDF9C6;
+    background: #FFBE00;
   }
+
   & #expandApp {
-    background: #96E1C7;
+    background: #00D645;
+  }
+
+  & .fa {
+    opacity: 0;
+  }
+
+  &:hover .fa {
+    opacity: 1;
+    color: #222326;
   }
 }
 


### PR DESCRIPTION
Hi guys :) 
For my first contrib I decided to improve a bit the top toolbar for macintosh (my current OS).

To answer these issues https://github.com/Soundnode/soundnode-app/issues/501 and https://github.com/Soundnode/soundnode-app/issues/533 I mainly changed the close / mini / maxmimize buttons to be smaller and more colorful. And changed a bit the Y position of elements (search bar and buttons).

Here's some screenshots of the differences.
Before : 
![topbefore](https://cloud.githubusercontent.com/assets/11151445/12699059/5c74c9a8-c7ae-11e5-9829-b7a1b6b12cc3.png)

After : 
![topafter](https://cloud.githubusercontent.com/assets/11151445/12699062/6a328634-c7ae-11e5-9888-260dc120b308.png)
