### PR TITLE
Minimize on Cmd+W, fixes #572

### DIFF
--- a/app/public/js/app.js
+++ b/app/public/js/app.js
@@ -136,6 +136,14 @@ app.run(function(
     });
 
     hotkeys.add({
+        combo: ['command+w'],
+        description: 'Minimize window',
+        callback: function() {
+            guiConfig.minimize();
+        }
+    });
+
+    hotkeys.add({
         combo: ['mod+,'],
         description: 'Open Settings',
         callback: function() {


### PR DESCRIPTION
Minimize the window on hitting Cmd+W on mac. Fixes [issue #572](https://github.com/Soundnode/soundnode-app/issues/572)