### PR TITLE
Added app arg to use a proxy

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -212,6 +212,7 @@
 
 <!-- app -->
 <script src="public/js/system/settings.js"></script>
+<script src="public/js/system/args.js"></script>
 <script src="public/js/system/authentication.js"></script>
 <script src="public/js/system/userConfig.js"></script>
 <script src="public/js/system/guiConfig.js"></script>

--- a/app/public/js/system/args.js
+++ b/app/public/js/system/args.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var gui = require('nw.gui');
+
+var args = {};
+
+args.parse = function() {
+    var self = this;
+    var argv = gui.App.argv;
+    
+    argv.forEach(function(arg, i) {
+        var value = argv[i+1]; // Used for arguments that require a value
+        
+        switch(arg) {
+            case '-p':
+            case '--proxy':
+                if (self.isValid(value)) gui.App.setProxyConfig(value);
+        }
+    });
+};
+
+// If the argument requires a value
+// 1. Check it exists
+// 2. Assert it is not another flag
+args.isValid = function(val) {
+    return !(val === undefined || /-.*/.test(val));
+};

--- a/app/public/js/system/core.js
+++ b/app/public/js/system/core.js
@@ -1,6 +1,7 @@
 "use strict";
 
 // Initialize modules
+args.parse();
 authentication.init();
 userConfig.windowState();
 userConfig.scaleInit();


### PR DESCRIPTION
Allows a proxy address to be passed as an argument to the application.

`./Soundnode-App --proxy 'proxy.domain.com:8080'`

#502 