### PR TITLE
mpris Integration

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -223,6 +223,7 @@
 <script src="public/js/common/SCapiService.js"></script>
 <script src="public/js/common/SC2apiService.js"></script>
 <script src="public/js/common/playerService.js"></script>
+<script src="public/js/common/mprisService.js"></script>
 <script src="public/js/common/notificationFactory.js"></script>
 <script src="public/js/common/modalFactory.js"></script>
 

--- a/app/public/js/common/mprisService.js
+++ b/app/public/js/common/mprisService.js
@@ -1,0 +1,86 @@
+"use strict";
+
+var gui = require("nw.gui");
+
+/**
+ * mpris integration for linux systems using DBUS
+ */
+app.factory("mprisService", function($rootScope, $log, $timeout, $window, $state) {
+    // media keys are supported on osx/windows already anyway
+    var supportedPlatforms = {
+        "linux": true,
+        "win32": false,
+        "darwin": false
+    };
+
+    // We check if the platform is supported
+    if(!supportedPlatforms[process.platform]) return false;
+
+    // Require mpris
+    var Player = require("mpris-service");
+
+    // Initialize & configure mpris
+    var mprisPlayer = Player({
+        canRaise: true,
+        name: "soundnode",
+        identity: "Soundnode",
+        desktopEntry: "soundnode",
+        supportedInterfaces: ["player"],
+        supportedUriSchemes: ["http", "file"],
+        supportedMimeTypes: ["audio/mpeg", "application/ogg"]
+    });
+
+    // Configuration
+    mprisPlayer.canControl = true;
+    mprisPlayer.canSeek = false;
+
+    // When the user asks dbus to show the player, we'll show it.
+    mprisPlayer.on("raise", function() {
+        gui.Window.get().show();
+    });
+
+    /** Functions **/
+
+    /**
+     * This is called whenever you play/resume a track.
+     *
+     * @param trackid   {number}    (SC Track ID)
+     * @param length    {number}    (Microseconds - Integer)
+     * @param artwork   {uri}
+     * @param title     {string}
+     * @param artist    {string}
+     */
+    mprisPlayer.play = function(trackid, length, artwork, title, artist) {
+        /** Overrides **/
+        length = 0; // UNSUPPORTED
+
+        mprisPlayer.metadata = {
+            "mpris:trackid": mprisPlayer.objectPath("track/" + trackid),
+            "mpris:length": length,
+            "mpris:artUrl": artwork,
+            "xesam:title": title,
+            "xesam:album": "",
+            "xesam:artist": artist
+        };
+
+        // Tell dbus/mpris that we're currently playing.
+        mprisPlayer.playbackStatus = "Playing";
+    };
+
+    /**
+     * Tells mpris that we're paused.
+     */
+    mprisPlayer.pause = function() {
+        mprisPlayer.playbackStatus = "Paused";
+    };
+
+    /**
+     * This is called whenever you stop playback
+     */
+    mprisPlayer.stop = function() {
+        mprisPlayer.playbackStatus = "Stopped";
+    };
+
+    // Return the mprisPlayer object
+    return mprisPlayer;
+});

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     "time-grunt": "^1.2.2",
     "webpack": "^1.12.2"
   },
+  "optionalDependencies": {
+      "dbus": "MarshallOfSound/node-dbus#linux-only",
+      "mpris-service": "MarshallOfSound/mpris-service"
+  },
   "dependencies": {
     "react": "^0.14.2",
     "react-dom": "^0.14.2",

--- a/tasks/nwjs.js
+++ b/tasks/nwjs.js
@@ -16,7 +16,8 @@ var config = {
             '<%= settings.app %>/public/img/**/*',
             '<%= settings.app %>/public/stylesheets/css/**/*',
             '<%= settings.app %>/dist/**/*',
-            './node_modules/universal-analytics/**/*'
+            './node_modules/universal-analytics/**/*',
+            './node_modules/mpris-service/**/*'
         ]
     };
 

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -3,6 +3,12 @@ module.exports = {
         stdout: true
     },
     target: {
-        command: 'webpack -p'
+        command: function() {
+            if("linux" === process.platform) {
+                return 'webpack -p && export PYTHON=/usr/bin/python2 && cd ./node_modules/mpris-service/node_modules/dbus && nw-gyp rebuild --target=0.12.3';
+            } else {
+                return 'webpack -p';
+            }
+        }
     }
 };


### PR DESCRIPTION
This adds media key support to linux (32/64bit)

It will remove the existing dbus-node folder from mpris-service's node_modules and then replace it with a patched version that supports nw0.12.3 then builds it. This will be simplified when upstream dbus-node gets patched too.

It currently won't support all the mpris features due to #639, but for now It only provides media key support :smile_cat: