### PR TITLE
Fixing the missing icons on hover other than the currently playing song. Fixes #665

### DIFF
--- a/app/public/stylesheets/sass/_components/_appState.scss
+++ b/app/public/stylesheets/sass/_components/_appState.scss
@@ -34,13 +34,6 @@ body[data-isVisible="true"] {
       vertical-align: middle;
     }
   }
-
-  & .fa-play {
-      display: none;
-    }
-  & .fa-pause {
-    display: block;
-  }
 }
 
 /* sub navigation states */


### PR DESCRIPTION
When the play icon is clicked on any of the song, sets the 'songPlaying' class on the div#app node and had the corresponding css which makes fa-play property to be display:none for all of the other tracks. 