### PR TITLE
Fix atwork typo

### DIFF
--- a/app/public/js/search/searchInputCtrl.js
+++ b/app/public/js/search/searchInputCtrl.js
@@ -82,7 +82,7 @@ app.controller('SearchInputCtrl', function ($scope, $http, $state, $window, SCap
 
                         for(var i = 0; i < 4; i++) {
                             var child = document.createElement('div');
-                            var image = data.collection[i].atwork_url || 'public/img/song-placeholder.png';
+                            var image = data.collection[i].artwork_url || 'public/img/song-placeholder.png';
                             child.className = 'dropdown-item';
                             child.id = data.collection[i].id;
 


### PR DESCRIPTION
I started running 0.6.3 and noticed quite a few errors in the dev tools around:

```
TypeError: Cannot read property 'atwork_url' of undefined
```

Figured this was just a typo, so I've gone ahead an updated it.

r? @weblancaster 