### PR TITLE
Use Fisher-Yates shuffle for shuffle functionality

### DIFF
--- a/app/public/js/common/playerService.js
+++ b/app/public/js/common/playerService.js
@@ -240,9 +240,7 @@ app.factory('playerService', function(
             player.elPlayer.currentTime = 0;
             return false;
         }
-        if ( $rootScope.shuffle && ! $rootScope.repeat ) {
-            utilsService.shuffle();
-        } else if ( ! $rootScope.repeat ) {
+        if ( ! $rootScope.repeat ) {
             queueService.prev();
         }
 
@@ -261,12 +259,14 @@ app.factory('playerService', function(
             return false;
         }
 
-        if ( $rootScope.shuffle && !$rootScope.repeat ) {
-            utilsService.shuffle();
-        } else if ( !$rootScope.repeat && utilsService.isLastTrackInQueue() ) {
-            utilsService.scrollToBottom();
-            utilsService.addLoadedTracks();
-        } else if ( !$rootScope.repeat && !utilsService.isLastTrackInQueue() ) {
+        if ( !$rootScope.repeat ) {
+            if ( utilsService.isLastTrackInQueue() ) { 
+                utilsService.scrollToBottom();
+                utilsService.addLoadedTracks();
+            }
+            if ( $rootScope.shuffle ) {
+                    utilsService.shuffle();
+            }
             queueService.next();
         }
 

--- a/app/public/js/common/utilsService.js
+++ b/app/public/js/common/utilsService.js
@@ -84,10 +84,19 @@ app.factory('utilsService', function(
      * @returns {number} [index in array]
      */
     Utils.shuffle = function() {
-        var max = queueService.size() - 1;
-        var min = 0;
-
-        queueService.currentPosition = Math.floor(Math.random() * (max - min) + min);
+        var past = queueService.getAll();
+        var next = queueService.currentPosition + 1;
+        var future = past.splice(next, past.length);
+    
+        var current = future.length, temp, random;
+        while (current) {
+            random = Math.floor(Math.random() * current--);
+            temp = future[current];
+            future[current] = future[random];
+            future[random] = temp;
+        }
+      
+        queueService.list = past.concat(future);
     };
 
     /**


### PR DESCRIPTION
Resolves #683 

Test case, in pure JavaScript:

``` js
var past = ['A', 'B - current', 'C', 'D', 'E', 'F']
var next = past.indexOf('B - current') + 1;
var future = past.splice(next, past.length);
    
var current = future.length, temp, random;
while (current) {
    random = Math.floor(Math.random() * current--);
    temp = future[current];
    future[current] = future[random];
    future[random] = temp;
}

console.log(past.concat(future).join('\n'));
```

**Sample output:**

>A
B - current
D
E
C
F

>A
B - current
E
C
F
D

>A
B - current
F
E
C
D

Please let me know if you have any questions, thanks!