### PR TITLE
Fixing the problem with duplicated songs in the "Likes" area

### DIFF
--- a/app/public/js/favorites/favoritesCtrl.js
+++ b/app/public/js/favorites/favoritesCtrl.js
@@ -35,8 +35,9 @@ app.controller('FavoritesCtrl', function (
         SCapiService.getNextPage()
             .then(function(data) {
                 for ( var i = 0; i < data.collection.length; i++ ) {
-                    $scope.originalData.push( data.collection[i] );
-                    $scope.data.push( data.collection[i] )
+                   // This makes the information repeat each time the data loads
+                   // $scope.originalData.push( data.collection[i] );
+                    $scope.data.push( data.collection[i] );
                 }
                 utilsService.updateTracksReposts(data.collection, true);
             }, function(error) {


### PR DESCRIPTION
Each time a person reaches the end of the scroll in the "Likes" area of the app, a double load of songs happen, like in #702 , the problem was that in the function of the favoritesCtrl.js there were two scopes in the "for" ($scope.originalData.push( data.collection[i] ) and  $scope.data.push( data.collection[i] ). 
I fixed this by looking at the tracksCtrl.js where only "$scope.data.push()" is needed to work.