### PR TITLE
Remove rest of code for sorting - fix for duplicated tracks

### DIFF
--- a/app/public/js/charts/chartsCtrl.js
+++ b/app/public/js/charts/chartsCtrl.js
@@ -149,7 +149,6 @@ app.controller('ChartsCtrl', function (
     }
 
     $scope.title = 'Top 50 - '+genre.title;
-    $scope.originalData = '';
     $scope.data = '';
     $scope.busy = false;
 
@@ -157,7 +156,6 @@ app.controller('ChartsCtrl', function (
     SC2apiService.getCharts(genre.link)
         .then(filterCollection)
         .then(function (collection) {
-            $scope.originalData = collection;
             $scope.data = collection;
             loadTracksInfo(collection);
         })
@@ -179,7 +177,6 @@ app.controller('ChartsCtrl', function (
         SC2apiService.getNextPage()
             .then(filterCollection)
             .then(function (collection) {
-                $scope.originalData = $scope.originalData.concat(collection);
                 $scope.data = $scope.data.concat(collection);
                 utilsService.updateTracksLikes(collection, true);
                 utilsService.updateTracksReposts(collection, true);

--- a/app/public/js/favorites/favoritesCtrl.js
+++ b/app/public/js/favorites/favoritesCtrl.js
@@ -10,13 +10,11 @@ app.controller('FavoritesCtrl', function (
         , params = 'linked_partitioning=1';
 
     $scope.title = 'Likes';
-    $scope.originalData = '';
     $scope.data = '';
     $scope.busy = false;
 
     SCapiService.get(endpoint, params)
         .then(function(data) {
-            $scope.originalData = data.collection;
             $scope.data = data.collection;
         }, function(error) {
             console.log('error', error);
@@ -35,7 +33,6 @@ app.controller('FavoritesCtrl', function (
         SCapiService.getNextPage()
             .then(function(data) {
                 for ( var i = 0; i < data.collection.length; i++ ) {
-                    $scope.originalData.push( data.collection[i] );
                     $scope.data.push( data.collection[i] )
                 }
                 utilsService.updateTracksReposts(data.collection, true);

--- a/app/public/js/profile/profileCtrl.js
+++ b/app/public/js/profile/profileCtrl.js
@@ -21,7 +21,6 @@ app.controller('ProfileCtrl', function (
     $scope.followers_count = '';
     $scope.busy = false;
     //tracks
-    $scope.originalData = '';
     $scope.data = '';
     $scope.follow_button_text = '';
 
@@ -39,7 +38,6 @@ app.controller('ProfileCtrl', function (
 
     SCapiService.getProfileTracks(userId)
         .then(function(data) {
-            $scope.originalData = data.collection;
             $scope.data = data.collection;
         }, function(error) {
             console.log('error', error);
@@ -68,7 +66,6 @@ app.controller('ProfileCtrl', function (
         SCapiService.getNextPage()
             .then(function(data) {
                 for ( var i = 0; i < data.collection.length; i++ ) {
-                    $scope.originalData.push( data.collection[i] );
                     $scope.data.push( data.collection[i] );
                 }
                 utilsService.updateTracksReposts(data.collection, true);

--- a/app/public/js/stream/streamCtrl.js
+++ b/app/public/js/stream/streamCtrl.js
@@ -10,14 +10,12 @@ app.controller('StreamCtrl', function (
     var tracksIds = [];
 
     $scope.title = 'Stream';
-    $scope.originalData = '';
     $scope.data = '';
     $scope.busy = false;
 
     SC2apiService.getStream()
         .then(filterCollection)
         .then(function (collection) {
-            $scope.originalData = collection;
             $scope.data = collection;
 
         })
@@ -39,7 +37,6 @@ app.controller('StreamCtrl', function (
         SC2apiService.getNextPage()
             .then(filterCollection)
             .then(function (collection) {
-                $scope.originalData = $scope.originalData.concat(collection);
                 $scope.data = $scope.data.concat(collection);
                 utilsService.updateTracksLikes(collection, true);
                 utilsService.updateTracksReposts(collection, true);

--- a/app/public/js/tag/tagCtrl.js
+++ b/app/public/js/tag/tagCtrl.js
@@ -11,12 +11,10 @@ app.controller('tagCtrl', function (
     var tagUrl = encodeURIComponent($stateParams.name);
 
     $scope.tag = $stateParams.name;
-    $scope.originalData = '';
     $scope.data = '';
 
     SCapiService.get('search/sounds', 'limit=32&q=*&filter.genre_or_tag=' + tagUrl)
         .then(function (data) {
-            $scope.originalData = data.collection;
             $scope.data = data.collection;
         }, function (error) {
             console.log('error', error);
@@ -34,7 +32,6 @@ app.controller('tagCtrl', function (
         SCapiService.getNextPage()
             .then(function (data) {
                 for (var i = 0; i < data.collection.length; i++) {
-                    $scope.originalData.push(data.collection[i]);
                     $scope.data.push(data.collection[i]);
                 }
                 utilsService.updateTracksReposts(data.collection, true);


### PR DESCRIPTION
Removed all unnecessary code that was added in partial sorting while ago, and causes dupes. Dupes should no longer show up in any view (charts/user/likes/stream).

@weblancaster please check if you still get any dupes.