### PR TITLE
Fix for wrong pointer on hover #619

### DIFF
--- a/app/public/stylesheets/sass/_components/_view-container.scss
+++ b/app/public/stylesheets/sass/_components/_view-container.scss
@@ -20,11 +20,15 @@
 }
 
 /*
-* Modal UI components
+* Modal UI components for adding song to playlist
 */
 .mediaBox_wrapper {
   float: left;
   margin: 0 5px;
+
+  &, & * {
+    cursor: pointer;
+  }
 
   &:first-child {
     margin-left: 0px;


### PR DESCRIPTION
By changing cursor type on the media wrapper div and the actual content of the media wrapper, fixes #619. I made sure the media wrapper css isn't used anywhere but the playlist addition modal, so there should be no side effects.