### PR TITLE
User favorite status synced across app (fixes #659)

### DIFF
--- a/app/public/js/common/favoriteSongDirective.js
+++ b/app/public/js/common/favoriteSongDirective.js
@@ -27,6 +27,7 @@ app.directive('favoriteSong', function(
                                 notificationFactory.warn("Song removed from likes!");
                                 $scope.favorite = false;
 								$scope.count -= 1;
+                                $rootScope.$broadcast("track::unfavorited", songId);
                             }
                         }, function() {
                             notificationFactory.error("Something went wrong!");
@@ -38,6 +39,7 @@ app.directive('favoriteSong', function(
                                 notificationFactory.success("Song added to likes!");
                                 $scope.favorite = true;
 								$scope.count += 1;
+                                $rootScope.$broadcast("track::favorited", songId);
                             }
                         }, function(status) {
                             notificationFactory.error("Something went wrong!");

--- a/app/public/js/common/playerService.js
+++ b/app/public/js/common/playerService.js
@@ -61,6 +61,7 @@ app.factory('playerService', function(
     player.elPlayerProgress = document.getElementById('player-progress');
     player.elPlayerDuration = document.getElementById('player-duration');
     player.elPlayerTimeCurrent = document.getElementById('player-timecurrent');
+    player.elPlayerFavorite = angular.element( document.querySelector('.player_favorite') );
     player.elThumb = document.getElementById('playerThumb');
     player.elTitle = document.getElementById('playerTitle');
     player.elUser = document.getElementById('playerUser');
@@ -164,6 +165,15 @@ app.factory('playerService', function(
                 gui.Window.get().show();
             };
         }
+
+        // Make sure the favorite heart is active if user liked it
+        var fav = this.elPlayerFavorite;
+        utilsService.updateTracksLikes([trackObj], true)
+        .then(function() {
+            if ( trackObj.user_favorite ) {
+                fav.addClass('active');
+            }
+        });
 
         $rootScope.isSongPlaying = true;
         $rootScope.$broadcast('activateQueue');

--- a/app/public/js/common/playerService.js
+++ b/app/public/js/common/playerService.js
@@ -183,7 +183,7 @@ app.factory('playerService', function(
         document.querySelector('.player_favorite').classList.remove('active');
     };
 
-    // Makes sure that future favorite changes will change the cache
+    // Updates cache when liking or unliking a song, so future checks will be correct
     $rootScope.$on('track::favorited', function(event, trackId) {
         utilsService.addCachedFavorite(trackId);
     });

--- a/app/public/js/common/playerService.js
+++ b/app/public/js/common/playerService.js
@@ -168,7 +168,7 @@ app.factory('playerService', function(
 
         // Make sure the favorite heart is active if user liked it
         var fav = this.elPlayerFavorite;
-        utilsService.updateTracksLikes([trackObj], true)
+        utilsService.updateTracksLikes([trackObj], true) // use cache to start
         .then(function() {
             if ( trackObj.user_favorite ) {
                 fav.addClass('active');
@@ -182,6 +182,14 @@ app.factory('playerService', function(
         // TODO: this should check if the current song is already favorited
         document.querySelector('.player_favorite').classList.remove('active');
     };
+
+    // Makes sure that future favorite changes will change the cache
+    $rootScope.$on('track::favorited', function(event, trackId) {
+        utilsService.addCachedFavorite(trackId);
+    });
+    $rootScope.$on('track::unfavorited', function(event, trackId) {
+        utilsService.removeCachedFavorite(trackId);
+    });
 
     /**
      * Responsible to play song

--- a/app/public/js/common/queueCtrl.js
+++ b/app/public/js/common/queueCtrl.js
@@ -83,6 +83,7 @@ app.controller('QueueCtrl', function(
                 if ( typeof status == "object" ) {
                     notificationFactory.success("Song added to likes!");
                     utilsService.markTrackAsFavorite(songId);
+                    $rootScope.$broadcast("track::favorited", songId);
                 }
             }, function(status) {
                 notificationFactory.error("Something went wrong!");

--- a/app/public/js/common/songDirective.js
+++ b/app/public/js/common/songDirective.js
@@ -14,6 +14,18 @@ app.directive('song', function ($rootScope, $window, playerService) {
                 });
             });
 
+            // Updating favorites when they get sent from other scope like the queue, stream, and player
+            $scope.$on('track::favorited', function(event, trackId) {
+                if ($scope.data.id == parseInt(trackId)) {
+                    $scope.data.user_favorite = true;
+                }
+            });
+            $scope.$on('track::unfavorited', function(event, trackId) {
+                if ($scope.data.id == parseInt(trackId)) {
+                    $scope.data.user_favorite = false;
+                }
+            });
+
         }
     }
 });

--- a/app/public/js/common/utilsService.js
+++ b/app/public/js/common/utilsService.js
@@ -134,6 +134,34 @@ app.factory('utilsService', function(
     };
 
     /**
+     * When manipulating likes after a page is loaded, it's necessary to
+     * manipulate the likesIds cache when you modify user_favorite like
+     * above. Used to sync the likes between player and everything else
+     * @param  {number or string} id - the song id to add to likes
+     */
+    Utils.addCachedFavorite = function(id) {
+        id = parseInt(id);
+        var index = Utils.likesIds.indexOf(id);
+        if (index == -1) {
+            Utils.likesIds.push(id);
+        }
+    }
+
+    /**
+     * When manipulating likes after a page is loaded, it's necessary to
+     * manipulate the likesIds cache when you modify user_favorite like
+     * above. Used to sync the likes between player and everything else
+     * @param  {number or string} id - the song id to remove from likes
+     */
+    Utils.removeCachedFavorite = function(id) {
+        id = parseInt(id);
+        var index = Utils.likesIds.indexOf(id);
+        if (index > -1) {
+            Utils.likesIds.splice(index, 1);
+        }
+    }
+
+    /**
      * Fetch ids of reposted tracks and apply them to existing collection
      * @param  {array} collection - stream collection or tracks array
      * @param  {boolean} fromCache  - if should make request to API

--- a/app/public/js/common/utilsService.js
+++ b/app/public/js/common/utilsService.js
@@ -125,8 +125,9 @@ app.factory('utilsService', function(
             }
             collection.forEach(function (item) {
                 var track = item.track || item;
+                var id = track.id || track.songId;
                 // modify each track by reference
-                track.user_favorite = Utils.likesIds.indexOf(track.id) > -1;
+                track.user_favorite = Utils.likesIds.indexOf(id) > -1;
             });
             return collection;
         });

--- a/app/public/js/player/playerCtrl.js
+++ b/app/public/js/player/playerCtrl.js
@@ -112,6 +112,7 @@ app.controller('PlayerCtrl', function (
                     if ( typeof status == "object" ) {
                         notificationFactory.warn("Song removed from likes!");
                         $event.currentTarget.classList.remove('active');
+                        $rootScope.$broadcast("track::unfavorited", track.songId);
                     }
                 }, function() {
                     notificationFactory.error("Something went wrong!");
@@ -122,12 +123,29 @@ app.controller('PlayerCtrl', function (
                     if ( typeof status == "object" ) {
                         notificationFactory.success("Song added to likes!");
                         $event.currentTarget.classList.add('active');
+                        $rootScope.$broadcast("track::favorited",  track.songId);
                     }
                 }, function(status) {
                     notificationFactory.error("Something went wrong!");
                 });
         }
     };
+
+    // Listen for updates from other scopes about favorites and unfavorites
+    $scope.$on('track::favorited', function(event, trackId) {
+        var track = queueService.getTrack();
+        if ( track && trackId == track.songId ) {
+            var elFavorite = document.querySelector('.player_favorite');
+            elFavorite.classList.add('active');
+        }
+    });
+    $scope.$on('track::unfavorited', function(event, trackId) {
+        var track = queueService.getTrack();
+        if ( track && trackId == track.songId ) {
+            var elFavorite = document.querySelector('.player_favorite');
+            elFavorite.classList.remove('active');
+        }
+    });
 
 
     /*

--- a/app/public/js/stream/streamCtrl.js
+++ b/app/public/js/stream/streamCtrl.js
@@ -48,24 +48,6 @@ app.controller('StreamCtrl', function (
             });
     };
 
-    // Updating favorites when they get sent from other scope like the queue and player
-    $scope.$on('track::favorited', function(event, trackId) {
-        for (var index in $scope.data) {
-            var track = $scope.data[index].track;
-            if ( trackId == track.id ) {
-                track.user_favorite = true;
-            }
-        }
-    });
-    $scope.$on('track::unfavorited', function(event, trackId) {
-        for (var index in $scope.data) {
-            var track = $scope.data[index].track;
-            if ( trackId == track.id ) {
-                track.user_favorite = false;
-            }
-        }
-    });
-
     function filterCollection(data) {
         return data.collection.filter(function (item) {
             // Keep only tracks (remove playlists, etc)

--- a/app/public/js/stream/streamCtrl.js
+++ b/app/public/js/stream/streamCtrl.js
@@ -48,6 +48,24 @@ app.controller('StreamCtrl', function (
             });
     };
 
+    // Updating favorites when they get sent from other scope like the queue and player
+    $scope.$on('track::favorited', function(event, trackId) {
+        for (var index in $scope.data) {
+            var track = $scope.data[index].track;
+            if ( trackId == track.id ) {
+                track.user_favorite = true;
+            }
+        }
+    });
+    $scope.$on('track::unfavorited', function(event, trackId) {
+        for (var index in $scope.data) {
+            var track = $scope.data[index].track;
+            if ( trackId == track.id ) {
+                track.user_favorite = false;
+            }
+        }
+    });
+
     function filterCollection(data) {
         return data.collection.filter(function (item) {
             // Keep only tracks (remove playlists, etc)


### PR DESCRIPTION
So, user liking of a song was pretty inconsistent before this PR. I made two large changes to make this better, inspired by #659, which this PR fixes part of.

First of all, if a user had liked a song before playing it, that status never showed up in the player at the bottom. It always showed a non-red heart until the user liked it (again). I get around this by using the util function for updating `user_favorite` when playing a new song.

Second, if you had a song playing and you liked it from the queue, stream, playlist, etc, it wouldn't update the heart in the player. And if you liked it from the player, it wouldn't change state on the stream, playlist, etc. There was no sharing of state or knowledge between views. I added a `$broadcast` notification on any like or dislike of a song to fix this. The song directive handles changing the status of `user_favorite` when it gets it, and root scope handles removing/adding to the likes cache in `utilService`.

This was extensively tested, from every state I could think of, and it seems to work consistently! State is shared for likes. This would all be much easier if there was one type of song data model that had state, and we saved that song model somewhere, only ever using that one object to read or write changes to. Something to think about for the future.

One more state-related bug this fix exposed is that liking a song from the player/queue doesn't update the count of the likes on the stream/playlist/etc page itself, as those pages use a `$scope.count` variable to keep track of counts (see `favoriteSongDirective` to see where this is being changed). IMO, we should be using the data's count property itself on those pages and then the notification handler in the song directive can also modify count values, rather than changing `$scope.count` where we call the API in `favoriteSongDirective`. But that requires a bit of refactoring, so it will be done in a future commit.