### PR TITLE
Logged in user text links to their profile page (fix #642)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -70,7 +70,7 @@
             <!-- user -->
             <div class="user" ng-controller="UserCtrl">
                 <div class="user_profile clearfix">
-                    <img ng-src="{{ data.avatar_url }}" alt="{{ data.username }}" class="user_thumb">
+                    <img ng-click="loadUserProfile()" ng-src="{{ data.avatar_url }}" alt="{{ data.username }}" class="user_thumb">
 
                     <div class="user_inner">
                         <a href="" class="user_name" title="{{ data.username}}" ng-click="loadUserProfile()">{{ data.username }}</a>

--- a/app/index.html
+++ b/app/index.html
@@ -73,7 +73,7 @@
                     <img ng-src="{{ data.avatar_url }}" alt="{{ data.username }}" class="user_thumb">
 
                     <div class="user_inner">
-                        <span class="user_name" title="{{ data.username}}">{{ data.username }}</span>
+                        <a href="" class="user_name" title="{{ data.username}}" ng-click="loadUserProfile()">{{ data.username }}</a>
                         <a href="" class="user_logOut" ng-click="logOut()">Log out</a>
                     </div>
                 </div>

--- a/app/public/js/profile/profileCtrl.js
+++ b/app/public/js/profile/profileCtrl.js
@@ -22,6 +22,7 @@ app.controller('ProfileCtrl', function (
     $scope.busy = false;
     //tracks
     $scope.data = '';
+    $scope.isLoggedInUser = userId == $rootScope.userId;
     $scope.follow_button_text = '';
 
 
@@ -79,7 +80,9 @@ app.controller('ProfileCtrl', function (
     };
 
     $scope.setFollowButtonText = function() {
-        if ($scope.isFollowing) {
+        if ($scope.isLoggedInUser) {
+            $scope.follow_button_text = 'Logged In';
+        } else if ($scope.isFollowing) {
             $scope.follow_button_text = 'Following';
         } else {
             $scope.follow_button_text = 'Follow';
@@ -87,12 +90,15 @@ app.controller('ProfileCtrl', function (
     };
 
     $scope.hoverIn = function() {
-        if ($scope.isFollowing) {
+        if ($scope.isFollowing && !$scope.isLoggedInUser) {
             $scope.follow_button_text = 'Unfollow';
         }
     };
 
     $scope.changeFollowing = function() {
+        if ($scope.isLoggedInUser) {
+            return // nothing to do
+        }
         if ($scope.isFollowing) {
             $scope.isFollowing = false;
             SCapiService.unfollowUser(userId)

--- a/app/public/js/user/userCtrl.js
+++ b/app/public/js/user/userCtrl.js
@@ -1,6 +1,6 @@
 'use strict'
 
-app.controller('UserCtrl', function ($rootScope, $scope, $window, SCapiService) {
+app.controller('UserCtrl', function ($rootScope, $scope, $window, $state, SCapiService) {
     var endpoint = 'me';
     var params = '';
 
@@ -19,4 +19,7 @@ app.controller('UserCtrl', function ($rootScope, $scope, $window, SCapiService) 
         guiConfig.close();
     }
 
+    $scope.loadUserProfile = function() {
+        $state.go('profile', { id: $rootScope.userId });
+    }
 });

--- a/app/public/stylesheets/sass/_components/_profile.scss
+++ b/app/public/stylesheets/sass/_components/_profile.scss
@@ -1,12 +1,12 @@
 .profile {
-  overflow: hidden;
-  margin-bottom: 25px;
+    overflow: hidden;
+    margin-bottom: 25px;
     display: flex;
 }
 
 .profile_box {
-  display: inline-block;
-  margin: 0 5px 0 5px;
+    display: inline-block;
+    margin: 0 5px 0 5px;
     flex: 1 0 300px;
 }
 

--- a/app/public/stylesheets/sass/_components/_songlist.scss
+++ b/app/public/stylesheets/sass/_components/_songlist.scss
@@ -37,10 +37,10 @@
 }
 
 .songList_item_song_button {
+  @extend .pointer;
   display: flex;
   font-size: 50px;
   width: 100%;
-  cursor: pointer;
   position: absolute;
   top: 0;
   height: 100%;
@@ -55,6 +55,10 @@
   & .fa:last-child {
     display: none;
   }
+}
+
+.pointer {
+  cursor: pointer;
 }
 
 li.active {
@@ -119,7 +123,7 @@ div.active {
   overflow: hidden;
   height: 46px;
   &:hover {
-    cursor: pointer;
+    @extend .pointer;
   }
 }
 
@@ -168,12 +172,12 @@ div.active {
       }
 
     &:hover {
-      cursor: pointer;
+      @extend .pointer;
       color: #FFF;
 
       & > .fa {
         color: #FFF;
-        cursor: pointer;
+        @extend .pointer;
       }
     }
 
@@ -211,7 +215,7 @@ div.active {
         color: #FFF;
         transition: $transitionFastValue;
         &:hover {
-            cursor: pointer;
+            @extend .pointer;
             background: #FFF;
             color: #000;
         }

--- a/app/public/stylesheets/sass/_components/_user.scss
+++ b/app/public/stylesheets/sass/_components/_user.scss
@@ -1,45 +1,48 @@
+$user_image_size: 40px;
+%clickable-block {
+    cursor: pointer;
+    display: block;
+}
+
 .user {
-    padding: 10px 0 0;
+    padding: 0 0 10px;
     overflow: hidden;
 }
 
 .user_thumb {
-    width: 30px;
-    height: 30px;
-    display: block;
-    border-radius: 50px;
+    @extend %clickable-block;
+    width: $user_image_size;
+    height: $user_image_size;
+    border-radius: $user_image_size;
     float: left;
-    cursor: pointer;
     -webkit-user-drag: none;
 }
 
 .user_inner {
+    @extend %clickable-block;
     float: left;
-    margin: 0 0 0 20px;
-}
-
-.user_name,
-.user_logOut {
-    font-weight: normal;
-    display: block;
+    margin: 0 0 0 10px;
+    cursor: pointer;
 }
 
 .user_name {
-    font-size: 12px;
+    @extend %clickable-block;
+    font-size: 15px;
     color: #fff;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     width: 128px;
+    line-height: 22px;
 }
 
 .user_logOut {
+    @extend %clickable-block;
     font-size: 10px;
-    cursor: pointer;
 }
 
 .user_info {
-    margin: 10px 0 0;
+    margin: 15px 0 0;
     font-size: 13px;
 }
 
@@ -53,7 +56,6 @@
 
     & small,
     & strong {
-        cursor: pointer;
-        display: block;
+        @extend %clickable-block;
     }
 }

--- a/app/views/common/tracks.html
+++ b/app/views/common/tracks.html
@@ -34,12 +34,12 @@
 
     <h3 class="songList_item_song_info clearfix">
         <div class="songList_item_song_user selectable-text">
-            <a ui-sref="profile({id: {{data.user.id}}})">
+            <a class="pointer" ui-sref="profile({id: {{data.user.id}}})">
                 {{ data.user.username }}
             </a>
             <span class="songList_item_repost" ng-if="type === 'track-repost'">
                 <i class="fa fa-retweet"></i>
-                <a ui-sref="profile({ id: {{ user.id }} })" title="Reposted by {{ user.username }}">
+                <a class="pointer" ui-sref="profile({ id: {{ user.id }} })" title="Reposted by {{ user.username }}">
                     {{ user.username }}
                 </a>
             </span>

--- a/app/views/profile/profile.html
+++ b/app/views/profile/profile.html
@@ -5,7 +5,7 @@
             <img ng-src="{{ showBigArtwork (profile_data.avatar_url) }}" alt="{{ profile_data.username }}" class="songList_item_artwork">
         </div>
         <div class="profile_box">
-            <button ng-click="changeFollowing()" ng-mouseover="hoverIn()" ng-mouseleave="setFollowButtonText()" ng-class="{active: isFollowing}" class="button follow_button">{{follow_button_text}}</button>
+            <button ng-hide="isLoggedInUser" ng-click="changeFollowing()" ng-mouseover="hoverIn()" ng-mouseleave="setFollowButtonText()" ng-class="{active: isFollowing}" class="button follow_button">{{follow_button_text}}</button>
             <h1 class="selectable-text">{{profile_data.username}}</h1>
             <h3>Followers: {{followers_count}}</h3>
             <p class="profile_description selectable-text" text-collapse text-max-height="205" text-to-collapse="{{profile_data.description}}"></p>


### PR DESCRIPTION
Click the username at top left to link to their profile page per #642. Doesn't show reposts, but ordinary profiles don't show reposts, so loading reposts should be a separate issue IMO. A few changes came together for this:

1) Slight tweaking of css of logged in user to make it clearer
2) $state.go to $rootscope.userId's profile from there
3) On profile page, not showing follow button if user is the logged in user (since following/unfollowing yourself makes no sense)