### PR TITLE
Add tray icon for Windows

### DIFF
--- a/app/public/js/settings/settingsCtrl.js
+++ b/app/public/js/settings/settingsCtrl.js
@@ -30,7 +30,7 @@ app.controller('SettingsCtrl', function ($scope, notificationFactory) {
         window.localStorage.minimizeToTray = $scope.minimize;
     };
 
-    $scope.showTraySettings = (process.platform === 'win32');
+    $scope.showTraySettings = window.settings.traySupport();
 
     /**
      * Clea storage which remove everything stored in window.localStorage

--- a/app/public/js/settings/settingsCtrl.js
+++ b/app/public/js/settings/settingsCtrl.js
@@ -17,6 +17,22 @@ app.controller('SettingsCtrl', function ($scope, notificationFactory) {
     };
 
     /**
+     * Enable or disable minimize to tray
+     * ONLY FOR WINDOWS OS
+     */
+    if ( window.localStorage.minimizeToTray ) {
+        $scope.minimize = JSON.parse(window.localStorage.minimizeToTray);
+    } else {
+        window.localStorage.minimizeToTray = $scope.minimize = false;
+    }
+
+    $scope.minimizeSettings = function() {
+        window.localStorage.minimizeToTray = $scope.minimize;
+    };
+
+    $scope.showTraySettings = (process.platform === 'win32');
+
+    /**
      * Clea storage which remove everything stored in window.localStorage
      */
     $scope.cleanStorage = function() {

--- a/app/public/js/system/guiConfig.js
+++ b/app/public/js/system/guiConfig.js
@@ -42,6 +42,64 @@ gui.App.on('reopen', function() {
     guiConfig.getGUI.show();
 });
 
+guiConfig.tray;
+
+// Get the minimize event
+guiConfig.getGUI.on('minimize', function() {
+    if (window.localStorage.minimizeToTray === 'false' || process.platform !== "win32") return false;
+    this.hide();
+    console.log('dde');
+
+    // Show tray
+    this.tray = new gui.Tray({ title: 'Soundnode', icon: 'soundnode.png' });
+
+    // Build tray menu
+    var trayMenu = new gui.Menu();
+
+    // Open
+    trayMenu.append(
+        new gui.MenuItem({
+        label: 'Open',
+        click: function() {
+            guiConfig.getGUI.show();
+        }
+    }));
+
+    // Developer Tools
+    trayMenu.append(
+        new gui.MenuItem({
+        label: 'Developer Tools',
+        click: function() {
+            guiConfig.openDevTools();
+        }
+    }));
+
+    // Separator
+    trayMenu.append(
+        new gui.MenuItem({
+        type: 'separator'
+    }));
+
+    // Exit
+    trayMenu.append(
+        new gui.MenuItem({
+        label: 'Exit',
+        click: function() {
+            gui.App.closeAllWindows();
+            this.close(true);
+        }
+    }));
+
+    // Assign menu to tray
+    this.tray.menu = trayMenu;
+
+    // Show window and remove tray when clicked
+    this.tray.on('click', function() {
+        guiConfig.getGUI.show();
+        this.remove();
+        guiConfig.tray = null;
+    });
+});
 // open dev tools
 guiConfig.openDevTools = function () {
     guiConfig.getGUI.showDevTools();

--- a/app/public/js/system/guiConfig.js
+++ b/app/public/js/system/guiConfig.js
@@ -42,19 +42,26 @@ gui.App.on('reopen', function() {
     guiConfig.getGUI.show();
 });
 
-guiConfig.tray;
 
 // Get the minimize event
 guiConfig.getGUI.on('minimize', function() {
-    if (window.localStorage.minimizeToTray === 'false' || process.platform !== "win32") return false;
+    if (window.localStorage.minimizeToTray === 'false' || !window.settings.traySupport()) {
+        return false;
+    }
     this.hide();
-    console.log('dde');
 
     // Show tray
     this.tray = new gui.Tray({ title: 'Soundnode', icon: 'soundnode.png' });
 
     // Build tray menu
-    var trayMenu = new gui.Menu();
+    var trayMenu = new gui.Menu(),
+        playerElement = document.querySelector('[ng-controller=PlayerCtrl]'),
+        playerScope = angular.element(playerElement).scope();
+
+    // Separator
+    var separator = new gui.MenuItem({
+        type: 'separator'
+    });
 
     // Open
     trayMenu.append(
@@ -74,11 +81,44 @@ guiConfig.getGUI.on('minimize', function() {
         }
     }));
 
-    // Separator
+    // Seperator
+    trayMenu.append(separator);
+
+    // Play/Pause
     trayMenu.append(
         new gui.MenuItem({
-        type: 'separator'
-    }));
+            label: 'Play / Pause',
+            click: function() {
+                playerScope.playPause();
+            }
+        })
+    );
+
+    // Seperator
+    trayMenu.append(separator);
+
+    // Next
+    trayMenu.append(
+        new gui.MenuItem({
+            label: 'Next',
+            click: function() {
+                playerScope.nextSong();
+            }
+        })
+    );
+
+    // Previous
+    trayMenu.append(
+        new gui.MenuItem({
+            label: 'Previous',
+            click: function() {
+                playerScope.prevSong();
+            }
+        })
+    );
+
+    // Separator
+    trayMenu.append(separator);
 
     // Exit
     trayMenu.append(

--- a/app/public/js/system/settings.js
+++ b/app/public/js/system/settings.js
@@ -10,3 +10,16 @@ window.settings.appVersion = '0.6.4';
 
 // GA >> DO NOT CHANGE OR USE THIS CODE <<
 window.settings.visitor = ua('UA-67310953-1');
+
+// Simple function to check whether OS supports minimize to tray option
+window.settings.traySupport = function () {
+    //List of supported OS for minimize for tray option
+    var os = {
+        "win32": true,
+        "linux32": false,
+        "linux64": false,
+        "darwin": false
+    };
+
+    return os[process.platform] || false;
+};

--- a/app/public/stylesheets/sass/_components/_topFrame.scss
+++ b/app/public/stylesheets/sass/_components/_topFrame.scss
@@ -74,6 +74,7 @@
     margin: 0;
     padding: 7px 14px 7px;
     border-radius: 0;
+    font-size: 9px;
     &:hover {
       background: #2C2C2C;
       .fa {

--- a/app/views/settings/settings.html
+++ b/app/views/settings/settings.html
@@ -16,6 +16,18 @@
                 </div>
             </div>
         </li>
+        <li class="full-flex" ng-hide="!showTraySettings">
+            <div class="settings-container leftSide">
+                <h2>Tray</h2>
+                <label>Enable/Disable minimization to tray </label>
+            </div>
+            <div class="settings-switch">
+                <div class="onoffswitch">
+                    <input type="checkbox" class="onoffswitch-checkbox" name="minimize" id="minimizeSettings" ng-model="minimize" ng-change="minimizeSettings()" ng-checked="minimize">
+                    <label class="onoffswitch-label" for="minimizeSettings"></label>
+                </div>
+            </div>
+        </li>
         <li class="full-flex">
             <div class="settings-container leftSide">
                 <h2>Clean local storage</h2>


### PR DESCRIPTION
This PR adds ability to minimize to tray for Windows OS.  It can be enabled/disabled trough settings toggle, disabled by default, and only Windows OS users should be able to see it.

Icon in taskbar doesn't look too good - too much details in icon, but it works. As well it has 3 element menu (Open, Dev Tools and Exit).

It resolves couple issues like: #489 #726 

@weblancaster please check if everything works on OSX as it should (toggle should not be visible etc.)

//EDIT: also small fix for window buttons on Windows.