### PR TITLE
Fix scale init

### DIFF
--- a/app/public/js/system/userConfig.js
+++ b/app/public/js/system/userConfig.js
@@ -63,6 +63,6 @@ userConfig.scaleWindow = function(scaleValue){
 userConfig.scaleInit = function() {
     if ( ! window.localStorage.scale ) {
         window.localStorage.setItem('scale', 1);
-        window.document.getElementsByTagName("body")[0].style.zoom = window.localStorage.scale;
     }
+    window.document.getElementsByTagName("body")[0].style.zoom = window.localStorage.scale;
 };


### PR DESCRIPTION
The zoom/scale wasn't being set at runtime due to it being unreachable if you had actually scaled your window previously. :+1: