### PR TITLE
Temporarily turn MPRIS support off

### DIFF
--- a/app/public/js/common/mprisService.js
+++ b/app/public/js/common/mprisService.js
@@ -8,7 +8,7 @@ var gui = require("nw.gui");
 app.factory("mprisService", function($rootScope, $log, $timeout, $window, $state) {
     // media keys are supported on osx/windows already anyway
     var supportedPlatforms = {
-        "linux": true,
+        "linux": false,
         "win32": false,
         "darwin": false
     };


### PR DESCRIPTION
This disables mpris on linux until a better solution for the build can be figured out.

Closes #830