### PR TITLE
Remove mpris from build & prevent mpris from firing functions

### DIFF
--- a/app/public/js/common/playerService.js
+++ b/app/public/js/common/playerService.js
@@ -185,7 +185,7 @@ app.factory('playerService', function(
         document.querySelector('.player_favorite').classList.remove('active');
 
         // mpris only supports linux
-        if(process.platform === "linux") {
+        if(process.platform === "linux" && mprisService) {
             // tell mpris that we're now playing & send off the attributes for dbus to use.
             mprisService.play("0", duration, trackObj.songThumbnail, trackObj.songTitle, trackObj.songUser);
         }
@@ -212,7 +212,7 @@ app.factory('playerService', function(
         /**
          * linux mpris passthrough for media keys & desktop integration
          */
-        if(process.platform === "linux") {
+        if(process.platform === "linux" && mprisService) {
             mprisService.play("0", duration, player.elThumb.src, player.elTitle.innerHTML, player.elUser.innerHTML);
         }
     };
@@ -228,7 +228,7 @@ app.factory('playerService', function(
         /**
          * linux mpris passthrough for media keys & desktop integration
          */
-        if(process.platform === "linux") {
+        if(process.platform === "linux" && mprisService) {
             mprisService.pause();
         }
     };

--- a/app/public/js/player/playerCtrl.js
+++ b/app/public/js/player/playerCtrl.js
@@ -226,7 +226,7 @@ app.controller('PlayerCtrl', function (
     /**
      * Add native media shortcuts for linux based systems
      */
-     if(process.platform === "linux") {
+     if(process.platform === "linux" && mprisService) {
          // Set a default state
          mprisService.playbackStatus = mprisService.playbackStatus || "Stopped";
 

--- a/package.json
+++ b/package.json
@@ -29,10 +29,6 @@
     "time-grunt": "^1.2.2",
     "webpack": "^1.12.2"
   },
-  "optionalDependencies": {
-      "dbus": "MarshallOfSound/node-dbus#linux-only",
-      "mpris-service": "MarshallOfSound/mpris-service"
-  },
   "dependencies": {
     "react": "^0.14.2",
     "react-dom": "^0.14.2",

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -4,11 +4,7 @@ module.exports = {
     },
     target: {
         command: function() {
-            if("linux" === process.platform) {
-                return 'webpack -p && export PYTHON=/usr/bin/python2 && cd ./node_modules/mpris-service/node_modules/dbus && nw-gyp rebuild --target=0.12.3';
-            } else {
-                return 'webpack -p';
-            }
+            return 'webpack -p';
         }
     }
 };


### PR DESCRIPTION
Removes mpris from the build process & will check if mprisService is truthy (It returns false if its not supported so the if statements will not be truthy currently)