### PR TITLE
Added height to player_progress_wrapper to avoid overlay with control buttons

### DIFF
--- a/app/public/stylesheets/sass/_components/_player.scss
+++ b/app/public/stylesheets/sass/_components/_player.scss
@@ -156,6 +156,7 @@
     // 1px horizontal protection area for window mouseleave workaround
     padding: 0 1px;
     top: 0;
+    height: 20px;
     left: 0;
     width: 100%;
 }


### PR DESCRIPTION
This closes #882.

the wrapper was too high so it overlayed the buttons and these were not clickable.