### PR TITLE
Add queuing functionality similar to Spotify's "Up Next" functionality

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -263,6 +263,7 @@
 <script src="public/js/common/tracksDirective.js"></script>
 <script src="public/js/common/playlistDirective.js"></script>
 <script src="public/js/common/queueListDirective.js"></script>
+<script src="public/js/common/queueDirective.js"></script>
 
 <!-- filters / utils -->
 <script src="public/js/common/utilsService.js"></script>

--- a/app/public/js/common/playerService.js
+++ b/app/public/js/common/playerService.js
@@ -114,11 +114,11 @@ app.factory('playerService', function(
                 queueService.insert(currentElData);
                 queueService.push(currentElSiblings);
             } else {
-
                 // find track in the Queue
                 trackPosition = queueService.find(currentElData.songId);
                 if ( trackPosition === 0 || trackPosition > 0 ) {
                     queueService.currentPosition = trackPosition;
+                    queueService.queueUpStart = null;
                 } else {
                     queueService.insert(currentElData);
                     queueService.next();

--- a/app/public/js/common/queueCtrl.js
+++ b/app/public/js/common/queueCtrl.js
@@ -44,8 +44,7 @@ app.controller('QueueCtrl', function(
             return;
         }
 
-        var trackId = queueService.getTrack().songId;
-        var track = document.querySelector('.queueListView_list_item[data-song-id="' + trackId + '"]');
+        var track = document.querySelector('.queueListView_list_item[data-queue-position="' + queueService.currentPosition + '"]');
         var oldActive = document.querySelector('.queueListView_list_item.active');
 
         if ( oldActive ) {

--- a/app/public/js/common/queueDirective.js
+++ b/app/public/js/common/queueDirective.js
@@ -1,0 +1,21 @@
+'use strict';
+
+app.directive('queueUp', function (
+    $rootScope, queueService
+) {
+    return {
+        restrict: 'A',
+
+        link: function ($scope, elem, attrs) {
+            var currentEl;
+
+            elem.bind('click', function () {
+                currentEl = this;
+
+                $scope.$apply(function() {
+                    queueService.insert($(currentEl).data(), true);
+                });
+            });
+        }
+    };
+});

--- a/app/public/js/common/queueService.js
+++ b/app/public/js/common/queueService.js
@@ -36,6 +36,7 @@ app.factory('queueService', function() {
      */
     Queue.clear = function() {
         this.list.length = this.currentPosition = 0;
+        this.queueUpStart = null;
     };
 
     /**
@@ -43,6 +44,8 @@ app.factory('queueService', function() {
      * @propriety currentPosition
      */
     Queue.currentPosition = 0;
+    Queue.queueUpStart = null;
+    Queue.queueUpLength = 0;
 
     /**
      * Push tracks from array to Queue list
@@ -71,13 +74,22 @@ app.factory('queueService', function() {
      * @param  currentElData [track obj]
      * @method insert
      */
-    Queue.insert = function(currentElData) {
+    Queue.insert = function(currentElData, queueUp) {
         if ( this.isEmpty() ) {
             this.list.splice(0, 0, currentElData);
             return;
         }
 
-        var addAt = this.currentPosition + 1;
+        if ( queueUp ) {
+          if ( this.queueUpStart === null ) {
+            this.queueUpStart = this.currentPosition + 1;
+            this.queueUpLength = 0;
+          }
+          var addAt = this.queueUpStart + this.queueUpLength++;
+        } else {
+          var addAt = this.currentPosition + 1;
+          this.queueUpStart = null;
+        }
         this.list.splice(addAt, 0, currentElData);
     };
 
@@ -99,6 +111,10 @@ app.factory('queueService', function() {
         if ( this.currentPosition !== 0 ) {
             --this.currentPosition;
         }
+
+        if ( this.currentPosition < (this.queueUpStart - 1) ) {
+          this.queueUpStart = null;
+        }
     };
 
     /**
@@ -109,6 +125,10 @@ app.factory('queueService', function() {
     Queue.next = function() {
         if ( this.currentPosition !== this.size() ) {
             ++this.currentPosition;
+        }
+
+        if ( this.currentPosition >= (this.queueUpStart + this.queueUpLength) ) {
+          this.queueUpStart = null;
         }
     };
 

--- a/app/views/common/queueList.html
+++ b/app/views/common/queueList.html
@@ -8,13 +8,14 @@
             <span class="labelColumn">ARTIST</span>
         </li>
         <li class="queueListView_list_item"
-            ng-repeat="item in data"
+            ng-repeat="item in data track by $index"
             song
             data-song-url="{{ item.songUrl }}"
             data-song-thumbnail="{{ item.songThumbnail }}"
             data-song-title="{{ item.songTitle }}"
             data-song-user="{{ item.songUser }}"
             data-song-id="{{ item.songId }}"
+            data-queue-position="{{ $index }}"
             ng-click="activateTrackInQueue($event)">
 
             <small class="queueListView_list_item_index">{{ $index + 1 }}</small>

--- a/app/views/common/tracks.html
+++ b/app/views/common/tracks.html
@@ -60,6 +60,16 @@
             <a data-song-id="{{ data.id }}" data-song-name="{{ data.title }}" playlist title="Add to playlist"> <i class="fa fa-bookmark"></i></a>
             <a href="{{ data.permalink_url }}" open-external target="_blank" title="Permalink"> <i class="fa fa-external-link"></i></a>
             <a copy-directive data-copy="{{ data.permalink_url }}" title="Copy"> <i class="fa fa-clipboard"></i></a>
+            <a
+              queue-up
+              title="Queue Up"
+              data-song-url="{{ data.stream_url }}"
+              data-song-thumbnail="{{ data.artwork_url }}"
+              data-song-title="{{ data.title }}"
+              data-song-user="{{ data.user.username }}"
+              data-song-user-id="{{ data.user.id }}"
+              data-song-id="{{ data.id }}"
+              > <i class="fa fa-plus"></i></a>
         </div>
         <div class="songList_item_additional_details">
             <span class="songList_item_genre" ui-sref="tag({name: data.genre})">#{{ data.genre }}</span>

--- a/app/views/track/track.html
+++ b/app/views/track/track.html
@@ -53,6 +53,7 @@
                 <a class="button inline" data-song-id="{{ track.id }}" data-song-name="{{ track.title }}" playlist title="Add to playlist"> <i class="fa fa-bookmark"></i> Add to playlist</a>
                 <a class="button inline" href="{{ track.permalink_url }}" open-external target="_blank" title="Permalink"> <i class="fa fa-external-link"></i> Permalink</a>
                 <a copy-directive class="button inline" data-copy="{{ track.permalink_url }}" title="Copy"> <i class="fa fa-clipboard"></i>Copy track link</a>
+                <!-- <a queue-up data-queue="track" class="button inline" title="Queue Up"> <i class="fa fa-clipboard"></i>Queue Up</a> -->
             </div>
         </div>
     </div>


### PR DESCRIPTION
- Relevant issue: https://github.com/Soundnode/soundnode-app/issues/530
- Created a directive to power an additional button that was placed in the views/common/tracks.html template that queues the song to be played sometime after the current.
- Modified how the queue decides what queue list item to add the 'active' class to
  - previously used songId, now matches the queueService's current position to the index of the queue list item
- Explanation of queuing implementation
  -  When a track is queued and a subqueue does NOT currently exist
      - a subqueue is created by noting the current track position in the queue and the subqueue length counter is set to zero
      - the track to be queued is inserted into the queue after the currently playing track
      - the subqueue length counter is incremented by one
  - When a track is queued and a subqueue does currently exist
    - the track to be queued is inserted into the queue at a position equal to the index of the start of the subqueue plus the current length of the subqueue (ie the end)
    - the subqueue length counter is incremented by one
  - Subqueue reset
    - a currently active subqueue will be reset under the following conditions:
      - the queue's current position moves OUTSIDE of the current subqueue (currentPosition < subqueueStart || currentPosition >= subqueueStart + subqueueLength), via using the previous or next buttons, or the player playing through the entire subqueue
      - a song is clicked, triggering immediate playback
    - after a subqueue reset, when another track is queued up it will be create a new subqueue as described above
  - NOTE: I understand I took liberties in deciding exactly how this behaves, if you want it to behave differently let me know