### PR TITLE
Restyle the playlist page to allow artwork 

### DIFF
--- a/app/public/js/playlists/collapsibleDirective.js
+++ b/app/public/js/playlists/collapsibleDirective.js
@@ -8,10 +8,8 @@ app.directive('collapsible', function ($rootScope) {
             elem.bind('click', function () {
                 if ( elem.parent().attr('data-playlist-hidden') === 'true' ) {
                     elem.parent().attr('data-playlist-hidden', 'false');
-                    elem.children().text('hide');
                 } else {
                     elem.parent().attr('data-playlist-hidden', 'true');
-                    elem.children().text('show');
                 }
             });
 

--- a/app/public/stylesheets/sass/_components/_playlist-songs.scss
+++ b/app/public/stylesheets/sass/_components/_playlist-songs.scss
@@ -2,7 +2,7 @@
   height: auto;
 }
 .songList_item.playlist[data-playlist-hidden="true"] {
-  height: 15px;
+  height: 115px;
 }
 
 .songList_item.playlist {
@@ -21,15 +21,26 @@
     margin: 0 0 10px 0;
     cursor: pointer;
     width: 100%;
-    float: none;
+    float: left;
 
-    & span {
-      cursor: pointer;
+    img {
+      float: left;
+      margin-right: 15px;
+    }
+
+    .title_meta {
+      float: left;
+
+      h2 {
+        margin-bottom: 10px;
+      }
     }
   }
 
   & .songList_item_songs_list {
-    margin: 20px 0 0 0;
+    margin: 10px 0 0 0;
+    float: left;
+    width: 100%;
   }
 
   & .songList_item_songs_list_item {

--- a/app/views/playlists/playlists.html
+++ b/app/views/playlists/playlists.html
@@ -11,16 +11,23 @@
                 data-playlist-hidden="true"
                 id="{{data.id}}">
 
-                <h4 class="songList_item_song_user" collapsible>{{ data.title }} playlist - <span>show</span></h4>
-                <span class="mediaBox_item_info">
-                    <i class="fa fa-list"></i> {{ data.track_count }}
-                </span>
-                <span class="mediaBox_item_info">
-                    <i class="fa fa-clock-o"></i> {{ formatSongDuration (data.duration) }}
-                </span>
-                <span class="songList_item_song_info">
-                    <a ng-click="removePlaylist(data.id)"> <i class="fa fa-trash"></i> delete playlist</a>
-                </span>
+                <div class="songList_item_song_user" collapsible>
+                  <img src="{{ data.artwork_url ? data.artwork_url : data.tracks[0].artwork_url }}" alt="">
+
+                  <div class="title_meta">
+                    <h2>{{ data.title }}</h2>
+
+                    <span class="mediaBox_item_info">
+                      <i class="fa fa-list"></i> {{ data.track_count }}
+                    </span>
+                    <span class="mediaBox_item_info">
+                      <i class="fa fa-clock-o"></i> {{ formatSongDuration (data.duration) }}
+                    </span>
+                    <span class="songList_item_song_info">
+                        <a ng-click="removePlaylist(data.id)"> <i class="fa fa-trash"></i> delete playlist</a>
+                    </span>
+                  </div>
+                </div>
 
                 <ul class="songList_item_songs_list">
                     <li class="songList_item_songs_list_item"


### PR DESCRIPTION
Quick restyle of the playlist page to support artwork with fallback to first track artwork image for playlists without set artwork. This gives the unfinished look of the playlist page a revamp as i found it very hard to quickly navigate the section.