### PR TITLE
Utilize system specific config locations.

### DIFF
--- a/app/public/js/common/configLocation.js
+++ b/app/public/js/common/configLocation.js
@@ -1,33 +1,58 @@
 const fs = require('fs-extra');
 const userHome = require('user-home');
+const mkdirp = require('mkdirp');
+
+/**
+ * Check if a given folder exists before trying to access any of it's children
+ * 
+ * @param {String} folder The folder we're checking
+ */
+const folderExists = folder => {
+    let exists = false;
+    fs.stat(folder, (err, stats) => { if (stats.isDirectory()) exists = true; });
+    return exists;
+};
 
 class Configuration {
 
     /**
-     * Get the configuration path
+     * Get the configuration folder location
      * 
-     * @returns {string} The location of the config
+     * @returns {string} The folder location of the config
      */
-    static get path () {
+    static get location () {
         let userConfigPath = null;
 
         /** Linux platforms - XDG Standard */
         if (process.platform === 'win32') {
-            userConfigPath = `${userHome}/.config/Soundnode/userConfig.json`;
+            userConfigPath = `${userHome}/.config/Soundnode`;
         }
 
 
         /** Linux platforms - XDG Standard */
         if (process.platform === 'linux') {
-            userConfigPath = `${userHome}/.config/Soundnode/userConfig.json`;
+            userConfigPath = `${userHome}/.config/Soundnode`;
         }
 
         /** Mac os configuration location */
         if (process.platform === 'darwin') {
-            userConfigPath = `${userHome}/Library/Preferences/Soundnode/userConfig.json`;
+            userConfigPath = `${userHome}/Library/Preferences/Soundnode`;
+        }
+
+        if (!folderExists(userConfigPath)) {
+            mkdirp(userConfigPath, err => { if (err) console.error(err); });
         }
 
         return userConfigPath;
+    }
+
+    /**
+     * Get the configuration path
+     * 
+     * @returns {string} The file location of the config
+     */
+    static get path () {
+        return `${this.location}/userConfig.json`
     }
 
     /**
@@ -45,7 +70,7 @@ class Configuration {
      * @returns {Boolean} True if the file exists
      */
     static get configExists () {
-        return fs.existsSync(this.path);
+        return fs.existsSync(`${this.path}`);
     }
 
 }

--- a/app/public/js/common/configLocation.js
+++ b/app/public/js/common/configLocation.js
@@ -2,22 +2,6 @@ const fs = require('fs-extra');
 const userHome = require('user-home');
 const mkdirp = require('mkdirp');
 
-/**
- * Check if a given folder exists before trying to access any of it's children
- * 
- * @param {String} folder The folder we're checking
- */
-const folderExists = folder => {
-    let exists = false;
-    fs.statSync(folder, (err, stats) => {
-        if (stats.isDirectory()) {
-            exists = true;
-        }
-    });
-
-    return exists;
-};
-
 class Configuration {
 
     /**
@@ -44,7 +28,7 @@ class Configuration {
             userConfigPath = `${userHome}/Library/Preferences/Soundnode`;
         }
 
-        if (!folderExists(userConfigPath)) {
+        if (!fs.statSync(userConfigPath).isDirectory()) {
             mkdirp(userConfigPath, err => {
                 if (err) {
                     console.error(err);

--- a/app/public/js/common/configLocation.js
+++ b/app/public/js/common/configLocation.js
@@ -1,0 +1,53 @@
+const fs = require('fs-extra');
+const userHome = require('user-home');
+
+class Configuration {
+
+    /**
+     * Get the configuration path
+     * 
+     * @returns {string} The location of the config
+     */
+    static get path () {
+        let userConfigPath = null;
+
+        /** Linux platforms - XDG Standard */
+        if (process.platform === 'win32') {
+            userConfigPath = `${userHome}/.config/Soundnode/userConfig.json`;
+        }
+
+
+        /** Linux platforms - XDG Standard */
+        if (process.platform === 'linux') {
+            userConfigPath = `${userHome}/.config/Soundnode/userConfig.json`;
+        }
+
+        /** Mac os configuration location */
+        if (process.platform === 'darwin') {
+            userConfigPath = `${userHome}/Library/Preferences/Soundnode/userConfig.json`;
+        }
+
+        return userConfigPath;
+    }
+
+    /**
+     * Get the config file
+     * 
+     * @returns {Object} Parsed version of the saved file
+     */
+    static get file () {
+        return JSON.parse(fs.readFileSync(`${this.path}`, 'utf-8'));
+    }
+
+    /**
+     * Ensure the config exists
+     * 
+     * @returns {Boolean} True if the file exists
+     */
+    static get configExists () {
+        return fs.existsSync(this.path);
+    }
+
+}
+
+module.exports = Configuration;

--- a/app/public/js/common/configLocation.js
+++ b/app/public/js/common/configLocation.js
@@ -9,7 +9,12 @@ const mkdirp = require('mkdirp');
  */
 const folderExists = folder => {
     let exists = false;
-    fs.stat(folder, (err, stats) => { if (stats.isDirectory()) exists = true; });
+    fs.statSync(folder, (err, stats) => {
+        if (stats.isDirectory()) {
+            exists = true;
+        }
+    });
+
     return exists;
 };
 
@@ -40,7 +45,11 @@ class Configuration {
         }
 
         if (!folderExists(userConfigPath)) {
-            mkdirp(userConfigPath, err => { if (err) console.error(err); });
+            mkdirp(userConfigPath, err => {
+                if (err) {
+                    console.error(err);
+                }
+            });
         }
 
         return userConfigPath;

--- a/app/public/js/common/configLocation.js
+++ b/app/public/js/common/configLocation.js
@@ -1,71 +1,79 @@
+'use strict';
+
 const fs = require('fs-extra');
 const userHome = require('user-home');
 const mkdirp = require('mkdirp');
 
-class Configuration {
+const configuration = {
 
-    /**
-     * Get the configuration folder location
-     * 
-     * @returns {string} The folder location of the config
-     */
-    static get location () {
-        let userConfigPath = null;
+  createUserConfig(userConfigPath) {
+    mkdirp(userConfigPath, err => {
+      if (err) {
+        console.error(err);
+      }
+    });
+  },
 
-        /** Windows platform */
-        if (process.platform === 'win32') {
-            userConfigPath = `${userHome}/.config/Soundnode`;
-        }
+  /**
+   * Get the configuration folder location
+   *
+   * @returns {string} The folder location of the config
+   */
+  getUserConfig() {
+    let userConfigPath = null;
 
-
-        /** Linux platforms - XDG Standard */
-        if (process.platform === 'linux') {
-            userConfigPath = `${userHome}/.config/Soundnode`;
-        }
-
-        /** Mac os configuration location */
-        if (process.platform === 'darwin') {
-            userConfigPath = `${userHome}/Library/Preferences/Soundnode`;
-        }
-
-        if (!fs.statSync(userConfigPath).isDirectory()) {
-            mkdirp(userConfigPath, err => {
-                if (err) {
-                    console.error(err);
-                }
-            });
-        }
-
-        return userConfigPath;
+    /** Windows platform */
+    if (process.platform === 'win32') {
+      userConfigPath = `${userHome}/.config/Soundnode`;
     }
 
-    /**
-     * Get the configuration path
-     * 
-     * @returns {string} The file location of the config
-     */
-    static get path () {
-        return `${this.location}/userConfig.json`
+
+    /** Linux platforms - XDG Standard */
+    if (process.platform === 'linux') {
+      userConfigPath = `${userHome}/.config/Soundnode`;
     }
 
-    /**
-     * Get the config file
-     * 
-     * @returns {Object} Parsed version of the saved file
-     */
-    static get file () {
-        return JSON.parse(fs.readFileSync(`${this.path}`, 'utf-8'));
+    /** Mac os configuration location */
+    if (process.platform === 'darwin') {
+      userConfigPath = `${userHome}/Library/Preferences/Soundnode`;
     }
 
-    /**
-     * Ensure the config exists
-     * 
-     * @returns {Boolean} True if the file exists
-     */
-    static get configExists () {
-        return fs.existsSync(`${this.path}`);
+    // create user config in path
+    // if there is no userConfig path
+    if (!fs.statSync(userConfigPath).isDirectory()) {
+      this.createUserConfig()
     }
+
+    return userConfigPath;
+  },
+
+  /**
+   * Get the configuration path
+   *
+   * @returns {string} The file location of the config
+   */
+  getPath() {
+    return `${this.getUserConfig()}/userConfig.json`
+  },
+
+  /**
+   * Get the config file
+   *
+   * @returns {Object} Parsed version of the saved file
+   */
+  getConfigfile() {
+    return JSON.parse(fs.readFileSync(`${this.getPath()}`, 'utf-8'));
+  },
+
+  /**
+   * Ensure the config exists
+   *
+   * @returns {Boolean} True if the file exists
+   */
+  containsConfig() {
+    return fs.existsSync(`${this.getPath()}`);
+  }
 
 }
 
-module.exports = Configuration;
+module.exports = configuration;

--- a/app/public/js/common/configLocation.js
+++ b/app/public/js/common/configLocation.js
@@ -28,7 +28,7 @@ class Configuration {
     static get location () {
         let userConfigPath = null;
 
-        /** Linux platforms - XDG Standard */
+        /** Windows platform */
         if (process.platform === 'win32') {
             userConfigPath = `${userHome}/.config/Soundnode`;
         }

--- a/app/public/js/system/guiConfig.js
+++ b/app/public/js/system/guiConfig.js
@@ -4,6 +4,7 @@ const {
   ipcRenderer
 } = require('electron');
 const fs = require('fs-extra');
+const userHome = require('user-home');
 
 let guiConfig = {};
 
@@ -28,7 +29,19 @@ guiConfig.maximize = function () {
 };
 
 guiConfig.logOut = function () {
-  fs.removeSync(`${__dirname}/userConfig.json`);
+  let _userConfigPath = `${__dirname}/app/public/js/system/userConfig.json`; // Windows specific for now
+
+  /** Linux platforms - XDG Standard */
+  if (process.platform === 'linux') {
+    _userConfigPath = `${userHome}/.config/Soundnode/userConfig.json`;
+  }
+
+  /** Mac os configuration location */
+  if (process.platform === 'darwin') {
+    _userConfigPath = `${userHome}/Library/Preferences/Soundnode/userConfig.json`;
+  }
+
+  fs.removeSync(`${_userConfigPath}`);
   this.destroy();
 };
 

--- a/app/public/js/system/guiConfig.js
+++ b/app/public/js/system/guiConfig.js
@@ -5,6 +5,7 @@ const {
 } = require('electron');
 const fs = require('fs-extra');
 const userHome = require('user-home');
+const Configuration = require('../common/configLocation');
 
 let guiConfig = {};
 
@@ -29,19 +30,7 @@ guiConfig.maximize = function () {
 };
 
 guiConfig.logOut = function () {
-  let _userConfigPath = `${__dirname}/app/public/js/system/userConfig.json`; // Windows specific for now
-
-  /** Linux platforms - XDG Standard */
-  if (process.platform === 'linux') {
-    _userConfigPath = `${userHome}/.config/Soundnode/userConfig.json`;
-  }
-
-  /** Mac os configuration location */
-  if (process.platform === 'darwin') {
-    _userConfigPath = `${userHome}/Library/Preferences/Soundnode/userConfig.json`;
-  }
-
-  fs.removeSync(`${_userConfigPath}`);
+  fs.removeSync(Configuration.path);
   this.destroy();
 };
 

--- a/app/public/js/system/guiConfig.js
+++ b/app/public/js/system/guiConfig.js
@@ -4,8 +4,7 @@ const {
   ipcRenderer
 } = require('electron');
 const fs = require('fs-extra');
-const userHome = require('user-home');
-const Configuration = require('../common/configLocation');
+const configuration = require('../common/configLocation');
 
 let guiConfig = {};
 
@@ -30,8 +29,8 @@ guiConfig.maximize = function () {
 };
 
 guiConfig.logOut = function () {
-  fs.removeSync(Configuration.path);
-  this.destroy();
+  fs.removeSync(configuration.getPath());
+  guiConfig.destroy();
 };
 
 module.exports = {

--- a/app/public/js/system/settings.js
+++ b/app/public/js/system/settings.js
@@ -2,19 +2,8 @@
 
 const ua = require('universal-analytics');
 const fs = require('fs');
-const userHome = require('user-home');
-
-let _userConfigPath = `${__dirname}/app/public/js/system/userConfig.json`; // Windows specific for now
-/** Linux platforms - XDG Standard */
-if (process.platform === 'linux') {
-    _userConfigPath = `${userHome}/.config/Soundnode/userConfig.json`;
-}
-
-/** Mac os configuration location */
-if (process.platform === 'darwin') {
-    _userConfigPath = `${userHome}/Library/Preferences/Soundnode/userConfig.json`;
-}
-const userConfig = JSON.parse(fs.readFileSync(`${_userConfigPath}`, 'utf-8'));
+const Configuration = require('../common/configLocation');
+const userConfig = Configuration.file;
 
 // Set up some core settings
 window.settings = {};

--- a/app/public/js/system/settings.js
+++ b/app/public/js/system/settings.js
@@ -1,9 +1,8 @@
 "use strict";
 
 const ua = require('universal-analytics');
-const fs = require('fs');
-const Configuration = require('../common/configLocation');
-const userConfig = Configuration.file;
+const configuration = require('../common/configLocation');
+const userConfig = configuration.getConfigfile();
 
 // Set up some core settings
 window.settings = {};

--- a/app/public/js/system/settings.js
+++ b/app/public/js/system/settings.js
@@ -2,7 +2,19 @@
 
 const ua = require('universal-analytics');
 const fs = require('fs');
-const userConfig = JSON.parse(fs.readFileSync(`${__dirname}/userConfig.json`, 'utf-8'));
+const userHome = require('user-home');
+
+let _userConfigPath = `${__dirname}/app/public/js/system/userConfig.json`; // Windows specific for now
+/** Linux platforms - XDG Standard */
+if (process.platform === 'linux') {
+    _userConfigPath = `${userHome}/.config/Soundnode/userConfig.json`;
+}
+
+/** Mac os configuration location */
+if (process.platform === 'darwin') {
+    _userConfigPath = `${userHome}/Library/Preferences/Soundnode/userConfig.json`;
+}
+const userConfig = JSON.parse(fs.readFileSync(`${_userConfigPath}`, 'utf-8'));
 
 // Set up some core settings
 window.settings = {};

--- a/main.js
+++ b/main.js
@@ -9,25 +9,12 @@ const {
   Menu
 } = require('electron');
 const windowStateKeeper = require('electron-window-state');
-const userHome = require('user-home');
+const Configuration = require('./app/public/js/common/configLocation');
 
 // custom constants
 const clientId = '342b8a7af638944906dcdb46f9d56d98';
 const redirectUri = 'http://sc-redirect.herokuapp.com/callback.html';
 const SCconnect = `https://soundcloud.com/connect?&client_id=${clientId}&redirect_uri=${redirectUri}&response_type=token`;
-let _userConfigPath = `${__dirname}/app/public/js/system/userConfig.json`; // Windows specific for now
-
-/** Linux platforms - XDG Standard */
-if (process.platform === 'linux') {
-  _userConfigPath = `${userHome}/.config/Soundnode/userConfig.json`;
-}
-
-/** Mac os configuration location */
-if (process.platform === 'darwin') {
-  _userConfigPath = `${userHome}/Library/Preferences/Soundnode/userConfig.json`;
-}
-
-const userConfigPath = _userConfigPath.slice(0); // Just to make sure it doesn't keep reference to the mutable string.
 
 let mainWindow;
 let authenticationWindow;
@@ -37,7 +24,7 @@ app.on('ready', () => {
 });
 
 function checkUserConfig() {
-  const userConfigExists = fs.existsSync(userConfigPath);
+  const userConfigExists = Configuration.configExists;
 
   if (userConfigExists) {
     initMainWindow();
@@ -84,7 +71,7 @@ function authenticateUser() {
 }
 
 function setUserData(accessToken) {
-  fs.writeFileSync(userConfigPath, JSON.stringify({
+  fs.writeFileSync(Configuration.path, JSON.stringify({
     accessToken: accessToken,
     clientId: clientId
   }), 'utf-8');

--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@ const {
   Menu
 } = require('electron');
 const windowStateKeeper = require('electron-window-state');
-const Configuration = require('./app/public/js/common/configLocation');
+const configuration = require('./app/public/js/common/configLocation');
 
 // custom constants
 const clientId = '342b8a7af638944906dcdb46f9d56d98';
@@ -24,9 +24,9 @@ app.on('ready', () => {
 });
 
 function checkUserConfig() {
-  const userConfigExists = Configuration.configExists;
+  const containsConfig = configuration.containsConfig();
 
-  if (userConfigExists) {
+  if (containsConfig) {
     initMainWindow();
   } else {
     authenticateUser();
@@ -71,7 +71,7 @@ function authenticateUser() {
 }
 
 function setUserData(accessToken) {
-  fs.writeFileSync(Configuration.path, JSON.stringify({
+  fs.writeFileSync(configuration.getPath(), JSON.stringify({
     accessToken: accessToken,
     clientId: clientId
   }), 'utf-8');

--- a/main.js
+++ b/main.js
@@ -9,12 +9,25 @@ const {
   Menu
 } = require('electron');
 const windowStateKeeper = require('electron-window-state');
+const userHome = require('user-home');
 
 // custom constants
 const clientId = '342b8a7af638944906dcdb46f9d56d98';
 const redirectUri = 'http://sc-redirect.herokuapp.com/callback.html';
 const SCconnect = `https://soundcloud.com/connect?&client_id=${clientId}&redirect_uri=${redirectUri}&response_type=token`;
-const userConfigPath = `${__dirname}/app/public/js/system/userConfig.json`;
+let _userConfigPath = `${__dirname}/app/public/js/system/userConfig.json`; // Windows specific for now
+
+/** Linux platforms - XDG Standard */
+if (process.platform === 'linux') {
+  _userConfigPath = `${userHome}/.config/Soundnode/userConfig.json`;
+}
+
+/** Mac os configuration location */
+if (process.platform === 'darwin') {
+  _userConfigPath = `${userHome}/Library/Preferences/Soundnode/userConfig.json`;
+}
+
+const userConfigPath = _userConfigPath.slice(0); // Just to make sure it doesn't keep reference to the mutable string.
 
 let mainWindow;
 let authenticationWindow;

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "fs-extra": "^2.0.0",
     "jquery": "^3.1.1",
     "lodash": "^4.17.4",
+    "mkdirp": "^0.5.1",
     "moment": "^2.17.1",
     "ng-dialog": "^1.0.0",
     "ng-infinite-scroll": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "toastr": "^2.1.2",
-    "universal-analytics": "^0.4.8"
+    "universal-analytics": "^0.4.8",
+    "user-home": "^2.0.0"
   }
 }


### PR DESCRIPTION
Linux configs utilize the XDG Specification `~/.config/soundnode/`
Mac os utilizes what i could gather as `~/Library/Preferences/Soundnode`

Not sure about the mac os location though.

# Related Issue(s)
#989 (JavaScript Error when login without ROOT permissions)
