### PR TITLE
[Feature] Added adjustable playback rate.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -183,6 +183,11 @@
           <input class="player_volume_range" ng-model="volume" type="range" name="volume_range" id="volume_range" min="0.0" max="1"
             step="0.1" ng-change="adjustVolume(volume)" data-isVisible="{{ isVisible }}" />
         </div>
+        <div class="player_volume">
+          <i class="fa fa-tachometer" ng-click="toggleSpeedRange()"></i>
+          <input class="player_volume_range" ng-model="speed" type="range" name="speed_range" id="speed_range" min="0.5" max="3.5"
+            step="0.1" ng-change="adjustSpeed(speed)" data-isVisible="{{ isSpeedVisible }}" />
+        </div>
         <audio id="player" controls src="" class="player_currentSong"></audio>
       </div>
     </div>

--- a/app/public/js/common/playerService.js
+++ b/app/public/js/common/playerService.js
@@ -85,6 +85,21 @@ app.factory('playerService', function (
   };
 
   /**
+   * Adjust player speed
+   * @param speed [playback rate]
+   * @method adjustSpeed
+   */
+  player.adjustSpeed = function(speed) {
+    if (typeof speed === 'undefined') {
+      return player.elPlayer.playbackRate;
+    }
+    if (speed >= 0.5 && speed <= 3.5) {
+      player.elPlayer.playbackRate = speed;
+      $window.localStorage.playbackRate = speed;
+    }
+  };
+
+  /**
    * Responsible to check if there's a song
    * playing if so check if the clicked song
    * is the current song playing and call pause

--- a/app/public/js/player/playerCtrl.js
+++ b/app/public/js/player/playerCtrl.js
@@ -25,6 +25,15 @@ app.controller('PlayerCtrl', function (
     $window.localStorage.volume = +$scope.volume;
   }
 
+  if ($window.localStorage.playbackRate) {
+    $scope.speed = +$window.localStorage.playbackRate;
+    playerService.adjustSpeed($scope.speed);
+  } else {
+    $scope.speed = 1.0;
+    playerService.adjustSpeed($scope.speed);
+    $window.localStorage.playbackRate = +$scope.speed;
+  }
+
   /**
    * Show/Hide volume range
    * @type {exports}
@@ -33,6 +42,14 @@ app.controller('PlayerCtrl', function (
   $scope.toggleRange = function () {
     $scope.isVisible = !$scope.isVisible;
   };
+  /**
+   * Show/Hide playback speed range
+   * @type {exports}
+   */
+  $scope.isSpeedVisible = false;
+  $scope.toggleSpeedRange = function () {
+    $scope.isSpeedVisible = !$scope.isSpeedVisible;
+  }
 
   /**
    * Responsible to send a new volume
@@ -42,6 +59,16 @@ app.controller('PlayerCtrl', function (
    */
   $scope.adjustVolume = function (volume) {
     playerService.volume(volume);
+  };
+
+  /**
+   * Responsible to send a new speed
+   * value on speed change
+   * @param speed [value of the speed]
+   * @method adjustSpeed
+   */
+  $scope.adjustSpeed = function (speed) {
+    playerService.adjustSpeed(speed);
   };
 
   $scope.playPause = function ($event) {


### PR DESCRIPTION
This is especially useful for those of us who use Soundcloud for listening to podcasts. Any respectable podcast app allows you to change the playback rate (typically up to 3.5x).

The implementation is almost identical to the volume slider.

Playback rate is saved to localStorage same as volume.

Possible improvements (todo):
- Add numbers to the slider such that the user can see precisely what speed they are playing at.
- Tweak styles to fit in with the UI better (currently it uses the same styles as the volume slider).

The icon is in the bottom right. 
<img width="1183" alt="screen shot 2017-10-06 at 4 35 43 pm" src="https://user-images.githubusercontent.com/6916093/31262003-94c71ce4-aab4-11e7-9612-34a8f8d11ad6.png">
<img width="1183" alt="screen shot 2017-10-06 at 4 36 10 pm" src="https://user-images.githubusercontent.com/6916093/31262012-9e493536-aab4-11e7-8051-368476653786.png">
