### PR TITLE
[Fix] Panic when using npm start on OSX fresh dev setup. Resolves #1017.

### DIFF
--- a/app/public/js/common/configLocation.js
+++ b/app/public/js/common/configLocation.js
@@ -54,7 +54,7 @@ const configuration = {
       throw `could not set config path for this OS ${process.platform}`
     }
 
-    createIfNotExist(userConfigPath)
+    this.createIfNotExist(userConfigPath)
 
     return userConfigPath;
   },

--- a/app/public/js/common/configLocation.js
+++ b/app/public/js/common/configLocation.js
@@ -14,6 +14,18 @@ const configuration = {
     });
   },
 
+  createIfNotExist(path) {
+    try {
+      const pathInfo = fs.statSync(path);
+      if (!pathInfo.isDirectory()) {
+        this.createUserConfig(path);
+      }
+    }
+    catch(error) {
+      this.createUserConfig(path);
+    }
+  },
+
   /**
    * Get the configuration folder location
    *
@@ -42,17 +54,8 @@ const configuration = {
       throw `could not set config path for this OS ${process.platform}`
     }
 
-    // create user config in path
-    // if there is no userConfig path
-    try {
-      const configFileInfo = fs.statSync(userConfigPath);
-      if (!configFileInfo.isDirectory()) {
-        this.createUserConfig(userConfigPath);
-      }
-    }
-    catch(error) {
-      this.createUserConfig(userConfigPath);
-    }
+    createIfNotExist(userConfigPath)
+
     return userConfigPath;
   },
 

--- a/app/public/js/common/configLocation.js
+++ b/app/public/js/common/configLocation.js
@@ -38,12 +38,26 @@ const configuration = {
       userConfigPath = `${userHome}/Library/Preferences/Soundnode`;
     }
 
-    // create user config in path
-    // if there is no userConfig path
-    if (!fs.statSync(userConfigPath).isDirectory()) {
-      this.createUserConfig()
+    // Guard to assert type of string.
+    if (typeof userConfigPath !== "string") {
+      throw `Could not set userConfigPath for this OS ${process.platform}`
     }
 
+    // create user config in path
+    // if there is no userConfig path
+    //
+    // fs.statSync will throw an exception if
+    // any directory along the path doesn't exist.
+    // Solution: use try catch.
+    try {
+      var fi = fs.statSync(userConfigPath);
+      if (!fi.isDirectory()) {
+        this.createUserConfig(userConfigPath);
+      }
+    }
+    catch(error) {
+      this.createUserConfig(userConfigPath);
+    }
     return userConfigPath;
   },
 

--- a/app/public/js/common/configLocation.js
+++ b/app/public/js/common/configLocation.js
@@ -27,7 +27,6 @@ const configuration = {
       userConfigPath = `${userHome}/.config/Soundnode`;
     }
 
-
     /** Linux platforms - XDG Standard */
     if (process.platform === 'linux') {
       userConfigPath = `${userHome}/.config/Soundnode`;
@@ -38,20 +37,16 @@ const configuration = {
       userConfigPath = `${userHome}/Library/Preferences/Soundnode`;
     }
 
-    // Guard to assert type of string.
-    if (typeof userConfigPath !== "string") {
-      throw `Could not set userConfigPath for this OS ${process.platform}`
+    /** Unsupported platform */
+    if (userConfigPath === null) {
+      throw `could not set config path for this OS ${process.platform}`
     }
 
     // create user config in path
     // if there is no userConfig path
-    //
-    // fs.statSync will throw an exception if
-    // any directory along the path doesn't exist.
-    // Solution: use try catch.
     try {
-      var fi = fs.statSync(userConfigPath);
-      if (!fi.isDirectory()) {
+      const configFileInfo = fs.statSync(userConfigPath);
+      if (!configFileInfo.isDirectory()) {
         this.createUserConfig(userConfigPath);
       }
     }


### PR DESCRIPTION
Panic occurs when the path ~/Library/Preferences/Soundnode does not exist (ie a fresh dev setup) since `getUserConfig()` uses `fs.statSync(..)`, which throws an exception instead of returning an error if the directory does not exist.

If the directory mentioned above does exist, all is fine. When it doesn't, such as on a fresh dev setup, every time you run 'npm start' you get a panic and the app crashes.

My solution to this is to wrap `fs.statSync(..)` in a try catch and problem solved.

Furthermore I added in a guard which checks the type of `userConfigPath`. The reason for this guard is so we can throw a useful exception rather than a generic undefined or null exception.