### PR TITLE
Changed version parameter of electron-packager to prevent deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "webpack:dev": "./node_modules/.bin/webpack -d --watch --config ./webpack.dev.js",
     "sass:prod": "./node_modules/.bin/node-sass --include-path ./app/public/stylesheets/sass --output-style compressed ./app/public/stylesheets/sass/app.scss ./app/public/stylesheets/css/app.css",
     "sass:dev": "./node_modules/.bin/node-sass --recursive --include-path ./app/public/stylesheets/sass --output-style expanded ./app/public/stylesheets/sass/app.scss ./app/public/stylesheets/css/app.css",
-    "package:osx": "electron-packager ./ Soundnode --platform=darwin --out ./dist/Soundnode --version 1.4.4 --overwrite --icon ./app/soundnode.ico",
-    "package:linux": "electron-packager ./ Soundnode --platform=linux --out ./dist/Soundnode --version 1.4.4 --overwrite --icon ./app/soundnode.icns",
-    "package:win32": "electron-packager ./ Soundnode --platform=win32 --out ./dist/Soundnode --version 1.4.4 --overwrite --icon ./app/soundnode.icns",
+    "package:osx": "electron-packager ./ Soundnode --platform=darwin --out ./dist/Soundnode --electron-version 1.4.4 --overwrite --icon ./app/soundnode.ico",
+    "package:linux": "electron-packager ./ Soundnode --platform=linux --out ./dist/Soundnode --electron-version 1.4.4 --overwrite --icon ./app/soundnode.icns",
+    "package:win32": "electron-packager ./ Soundnode --platform=win32 --out ./dist/Soundnode --electron-version 1.4.4 --overwrite --icon ./app/soundnode.icns",
     "package:all": "npm run package:osx && npm run package:linux && npm run package:win32"
   },
   "author": "Michael Lancaster",


### PR DESCRIPTION
Solves a very tiny deprecation warning.

This fixes the deprecation warning:
`The version parameter is deprecated, use electronVersion instead (or --electron-version in the CLI)`