### PR TITLE
Update configLocation.js

### DIFF
--- a/app/public/js/common/configLocation.js
+++ b/app/public/js/common/configLocation.js
@@ -40,9 +40,10 @@ const configuration = {
 
     // create user config in path
     // if there is no userConfig path
-    if (!fs.statSync(userConfigPath).isDirectory()) {
-      this.createUserConfig()
-    }
+    fs.ensureDir(userConfigPath, err => {
+      // console.log(err) // => null
+      // dir has now been created, including the directory it is to be placed in
+    })
 
     return userConfigPath;
   },


### PR DESCRIPTION
Fixes #1024

First time running this on a Mac so the userConfigPath does not exists. The code was erroring out on
```
 if (!fs.statSync(userConfigPath).isDirectory()) {
```

The new code is tested as working on Mac. 
```
createUserConfig(userConfigPath) // is probably no longer needed.
```