### PR TITLE
WIP: Use youtube-dl to bypass rate limit

### DIFF
--- a/app/public/js/common/playerService.js
+++ b/app/public/js/common/playerService.js
@@ -151,7 +151,9 @@ app.factory('playerService', function (
       trackObj.songThumbnail = 'public/img/song-placeholder.png';
     }
 
-    trackUrl = trackObj.songUrl + '?client_id=' + $window.scClientId;
+    //trackUrl = trackObj.songUrl + '?client_id=' + $window.scClientId;
+    // Fuck the rate limit, use youtube-dl to extract a streamable URL
+    trackUrl = require('child_process').execSync(`youtube-dl -g '${trackObj.songUrl}'`).toString();
 
     // check rate limit
     utilsService.isPlayable(trackUrl).then(function () {


### PR DESCRIPTION
This is a proof-of-concept that's not meant to be merged (so feel free to close this).

This uses youtube-dl to extract a streamable URL. I don't know how they get around any API limits but I'm guessing the clue might lie here:

https://github.com/rg3/youtube-dl/blob/a26a3c6d343a4da1a3739e3af39147545c51a05d/youtube_dl/extractor/soundcloud.py

In my opinion this is a better solution than requiring people to use their own API key since it's basically "plug and play", all you need is to have youtube-dl installed.