### PR TITLE
Hotfix for electron menu to enable defaults

### DIFF
--- a/app/public/js/settings/settingsCtrl.js
+++ b/app/public/js/settings/settingsCtrl.js
@@ -19,6 +19,7 @@ app.controller('SettingsCtrl', function ($scope, notificationFactory) {
 
     $scope.scClientId = function () {
         window.localStorage.scClientId = $scope.client_id;
+        window.settings.updateUserConfig();
     };
 
     /**

--- a/app/public/js/system/settings.js
+++ b/app/public/js/system/settings.js
@@ -3,6 +3,7 @@
 const ua = require('universal-analytics');
 const configuration = require('../common/configLocation');
 const userConfig = configuration.getConfigfile();
+const fs = require('fs-extra');
 
 // Set up some core settings
 window.settings = {};
@@ -18,3 +19,10 @@ window.scAccessToken = userConfig.accessToken;
 
 // set window clientId
 window.localStorage.setItem('scClientId', userConfig.clientId);
+
+window.settings.updateUserConfig = function () {
+    fs.writeFileSync(configuration.getPath(), JSON.stringify({
+        accessToken: userConfig.accessToken,
+        clientId: window.localStorage.scClientId
+    }), 'utf-8');
+}

--- a/main.js
+++ b/main.js
@@ -204,6 +204,7 @@ function menuBar() {
     },
     {
       role: 'view',
+      label: 'View',
       submenu: [
         {
           role: 'togglefullscreen'
@@ -225,9 +226,6 @@ function menuBar() {
           click() {
             require('electron').shell.openExternal('https://github.com/Soundnode/soundnode-app/blob/master/LICENSE.md')
           }
-        },
-        {
-          role: 'paste'
         }
       ]
     },

--- a/main.js
+++ b/main.js
@@ -221,12 +221,18 @@ function menuBar() {
           click() {
             require('electron').shell.openExternal('https://github.com/Soundnode/soundnode-app/blob/master/LICENSE.md')
           }
+        },
+        {
+          role: 'paste'
         }
       ]
     },
     {
-      role: 'window',
+      role: 'windowMenu',
       submenu: [
+        {
+          role: 'quit'
+        },
         {
           label: 'Reload',
           accelerator: 'CmdOrCtrl+R',

--- a/main.js
+++ b/main.js
@@ -199,7 +199,8 @@ function initializeMediaShortcuts() {
 function menuBar() {
   const template = [
     {
-      role: 'editMenu'
+      role: 'editMenu',
+      label: 'Soundnode'
     },
     {
       role: 'view',

--- a/main.js
+++ b/main.js
@@ -199,6 +199,9 @@ function initializeMediaShortcuts() {
 function menuBar() {
   const template = [
     {
+      role: 'editMenu'
+    },
+    {
       role: 'view',
       submenu: [
         {


### PR DESCRIPTION
This provides a fix for the remainder of #1037 & adds in things like quitting the application etc.

Mainly, it will bring in default edit & window menus from electron so we can out of the box have things like quit, copy/cut/paste etc without any added complexity to our own code.