### PR TITLE
Don't play if no track is queued

### DIFF
--- a/app/public/js/player/playerCtrl.js
+++ b/app/public/js/player/playerCtrl.js
@@ -45,11 +45,7 @@ app.controller('PlayerCtrl', function (
   };
 
   $scope.playPause = function ($event) {
-    if ($rootScope.isSongPlaying) {
-      playerService.pauseSong();
-    } else {
-      playerService.playSong();
-    }
+    togglePlayPause();
   };
 
   $scope.prevSong = function ($event) {
@@ -149,7 +145,9 @@ app.controller('PlayerCtrl', function (
    * the amount of times we define it.
    */
   var togglePlayPause = function () {
-    if ($rootScope.isSongPlaying) {
+    var track = queueService.getTrack();
+
+    if ($rootScope.isSongPlaying || track == null) {
       playerService.pauseSong();
     } else {
       playerService.playSong();


### PR DESCRIPTION
This should fix #1094 by grabbing the current track from the queueService. If nothing is returned then that means no track is currently selected.

I also switched to using `togglePlayPause()` method in `playPause` event since its already used everywhere else in the file.